### PR TITLE
优化solon 环境下对database dialect 配置的提示

### DIFF
--- a/sql-extension/sql-solon-plugin/src/main/java/com/easy/query/solon/integration/DbManager.java
+++ b/sql-extension/sql-solon-plugin/src/main/java/com/easy/query/solon/integration/DbManager.java
@@ -139,7 +139,7 @@ public class DbManager {
             String cfgPropPrefix = CommonConstant.TAG + "." + bw.name();
             dsProps = bw.context().cfg().getProp(cfgPropPrefix);
             if(dsProps.isEmpty() || !dsProps.containsKey("database")) {
-                throw new UnsupportedOperationException("Please set the configuration for the data source in the yml file with specific key " + cfgPropPrefix + ".database");
+                throw new UnsupportedOperationException("Please set the configuration for the data source "+bw.name()+" dialect in the yml file with specific key " + cfgPropPrefix + ".database");
             }
         } else {
             // all the data source bean must has a name


### PR DESCRIPTION

before:
```
Please select the correct database dialect. For solon-related configuration, set it in the yml file, for example:[easy-query.database: mysql]
```


after
```
Please set the configuration for the data source dialect in the yml file with specific key easy-query.dataSource_default.database
```
`dataSource_default` the bean name of data source
