### PR TITLE
nameConversion字符串转枚举时忽略大小写

### DIFF
--- a/sql-extension/sql-solon-plugin/src/main/java/com/easy/query/solon/integration/SolonEasyQueryProperties.java
+++ b/sql-extension/sql-solon-plugin/src/main/java/com/easy/query/solon/integration/SolonEasyQueryProperties.java
@@ -232,7 +232,7 @@ public class SolonEasyQueryProperties {
 
     public NameConversionEnum getNameConversion() {
         return getOrDef("name-conversion", nameConversion, v -> {
-            switch (v) {
+            switch (v == null ? null : v.toLowerCase()) {
                 case "default":
                     return NameConversionEnum.DEFAULT;
                 case "underlined":


### PR DESCRIPTION
为了便于将字符串转枚举，动态数据源中关于nameConversion的配置最终存储的都是大写的字符串，EQ的Solon插件中只考虑了小写的情况，导致最终的nameConversion出现了意外的结果（DEFAULT变成了UNDERLINED）
<img width="1186" height="640" alt="1b28fda9-d2ca-4479-8fad-935ef9e060c5" src="https://github.com/user-attachments/assets/1deb19bd-3b6d-480e-821a-30dd6ce5a945" />
