### PR TITLE
feat: 添加查询行级锁定支持

### DIFF
--- a/sql-core/src/main/java/com/easy/query/core/basic/api/select/ClientQueryable.java
+++ b/sql-core/src/main/java/com/easy/query/core/basic/api/select/ClientQueryable.java
@@ -127,6 +127,22 @@ public interface ClientQueryable<T1> extends Query<T1>,
 
     @NotNull ClientQueryable<T1> asNoTracking();
 
+    /**
+     * Enable row-level lock query and append {@code FOR UPDATE} to the generated SQL.
+     *
+     * <p>Requirements:
+     * <ul>
+     *     <li>Must be called inside an active transaction.</li>
+     *     <li>Only single-table query is supported in current version.</li>
+     * </ul>
+     *
+     * @return current queryable
+     */
+    @NotNull
+    default ClientQueryable<T1> forUpdate() {
+        throw new UnsupportedOperationException();
+    }
+
     @NotNull ClientQueryable<T1> useShardingConfigure(int maxShardingQueryLimit, ConnectionModeEnum connectionMode);
 
     @NotNull ClientQueryable<T1> useMaxShardingQueryLimit(int maxShardingQueryLimit);

--- a/sql-core/src/main/java/com/easy/query/core/basic/api/select/abstraction/AbstractClientQueryable.java
+++ b/sql-core/src/main/java/com/easy/query/core/basic/api/select/abstraction/AbstractClientQueryable.java
@@ -37,6 +37,7 @@ import com.easy.query.core.basic.api.select.impl.EasyClientQueryable;
 import com.easy.query.core.basic.api.select.impl.EasyCteClientQueryable;
 import com.easy.query.core.basic.api.select.provider.SQLExpressionProvider;
 import com.easy.query.core.basic.extension.track.TrackManager;
+import com.easy.query.core.basic.jdbc.conn.ConnectionManager;
 import com.easy.query.core.basic.jdbc.executor.ExecutorContext;
 import com.easy.query.core.basic.jdbc.executor.impl.def.EntityResultColumnMetadata;
 import com.easy.query.core.basic.jdbc.executor.impl.def.EntityResultMetadata;
@@ -53,6 +54,7 @@ import com.easy.query.core.context.QueryRuntimeContext;
 import com.easy.query.core.enums.EasyBehaviorEnum;
 import com.easy.query.core.enums.ExecuteMethodEnum;
 import com.easy.query.core.enums.MultiTableTypeEnum;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.enums.RelationTypeEnum;
 import com.easy.query.core.enums.SQLUnionEnum;
 import com.easy.query.core.enums.sharding.ConnectionModeEnum;
@@ -1818,6 +1820,26 @@ public abstract class AbstractClientQueryable<T1> implements ClientQueryable<T1>
     @Override
     public ClientQueryable<T1> asNoTracking() {
         entityQueryExpressionBuilder.getExpressionContext().getBehavior().removeBehavior(EasyBehaviorEnum.USE_TRACKING);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public ClientQueryable<T1> forUpdate() {
+        ConnectionManager connectionManager = runtimeContext.getConnectionManager();
+        if (!connectionManager.currentThreadInTransaction()) {
+            String queryName = EasyClassUtil.getSimpleName(queryClass());
+            throw new IllegalStateException("forUpdate requires an active transaction for query [" + queryName + "], please call beginTransaction() before forUpdate().");
+        }
+        if (entityQueryExpressionBuilder.getTables().size() > 1 || entityQueryExpressionBuilder.hasRelationTables()) {
+            String queryName = EasyClassUtil.getSimpleName(queryClass());
+            throw new IllegalStateException("forUpdate currently supports single-table queries only, query [" + queryName + "] contains join/relation tables.");
+        }
+        if (QueryLockEnum.FOR_UPDATE == entityQueryExpressionBuilder.getExpressionContext().getQueryLock()) {
+            String queryName = EasyClassUtil.getSimpleName(queryClass());
+            throw new IllegalStateException("forUpdate is already enabled on query [" + queryName + "], repeated calls are not supported.");
+        }
+        entityQueryExpressionBuilder.getExpressionContext().setQueryLock(QueryLockEnum.FOR_UPDATE);
         return this;
     }
 

--- a/sql-core/src/main/java/com/easy/query/core/enums/QueryLockEnum.java
+++ b/sql-core/src/main/java/com/easy/query/core/enums/QueryLockEnum.java
@@ -1,0 +1,11 @@
+package com.easy.query.core.enums;
+
+/**
+ * Query lock mode.
+ *
+ * @author xuejiaming
+ */
+public enum QueryLockEnum {
+    NONE,
+    FOR_UPDATE
+}

--- a/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/EasyExpressionContext.java
+++ b/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/EasyExpressionContext.java
@@ -11,6 +11,7 @@ import com.easy.query.core.context.QueryRuntimeContext;
 import com.easy.query.core.enums.ContextTypeEnum;
 import com.easy.query.core.enums.EasyBehaviorEnum;
 import com.easy.query.core.enums.ExecuteMethodEnum;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.enums.SQLExecuteStrategyEnum;
 import com.easy.query.core.enums.sharding.ConnectionModeEnum;
 import com.easy.query.core.exception.EasyQueryInvalidOperationException;
@@ -58,6 +59,7 @@ public class EasyExpressionContext implements ExpressionContext {
     private boolean deleteThrowException;
     private Object version;
     private ExecuteMethodEnum executeMethod = ExecuteMethodEnum.UNKNOWN;
+    private QueryLockEnum queryLock = QueryLockEnum.NONE;
     private SQLExecuteStrategyEnum sqlStrategy = SQLExecuteStrategyEnum.DEFAULT;
 
     private Integer maxShardingQueryLimit;
@@ -282,6 +284,16 @@ public class EasyExpressionContext implements ExpressionContext {
     }
 
     @Override
+    public void setQueryLock(QueryLockEnum queryLock) {
+        this.queryLock = queryLock == null ? QueryLockEnum.NONE : queryLock;
+    }
+
+    @Override
+    public QueryLockEnum getQueryLock() {
+        return queryLock;
+    }
+
+    @Override
     public void setMaxShardingQueryLimit(Integer maxShardingQueryLimit) {
         this.maxShardingQueryLimit = maxShardingQueryLimit;
     }
@@ -346,6 +358,7 @@ public class EasyExpressionContext implements ExpressionContext {
         otherExpressionContext.deleteThrow(this.deleteThrowException);
         otherExpressionContext.setVersion(this.version);
         otherExpressionContext.executeMethod(this.executeMethod);
+        otherExpressionContext.setQueryLock(this.queryLock);
         otherExpressionContext.useSQLStrategy(this.sqlStrategy);
         otherExpressionContext.setMaxShardingQueryLimit(this.maxShardingQueryLimit);
         otherExpressionContext.setConnectionMode(this.connectionMode);
@@ -462,6 +475,7 @@ public class EasyExpressionContext implements ExpressionContext {
         easyExpressionContext.deleteThrowException = this.deleteThrowException;
         easyExpressionContext.version = this.version;
         easyExpressionContext.executeMethod = this.executeMethod;
+        easyExpressionContext.queryLock = this.queryLock;
         easyExpressionContext.sqlStrategy = this.sqlStrategy;
         easyExpressionContext.maxShardingQueryLimit = this.maxShardingQueryLimit;
         easyExpressionContext.connectionMode = this.connectionMode;

--- a/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/EmptyExpressionContext.java
+++ b/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/EmptyExpressionContext.java
@@ -8,6 +8,7 @@ import com.easy.query.core.basic.jdbc.executor.ResultColumnMetadata;
 import com.easy.query.core.context.QueryRuntimeContext;
 import com.easy.query.core.enums.ContextTypeEnum;
 import com.easy.query.core.enums.ExecuteMethodEnum;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.enums.SQLExecuteStrategyEnum;
 import com.easy.query.core.enums.sharding.ConnectionModeEnum;
 import com.easy.query.core.expression.builder.core.ValueFilter;
@@ -159,6 +160,16 @@ public class EmptyExpressionContext implements ExpressionContext{
     @Override
     public ExecuteMethodEnum getExecuteMethod() {
         return null;
+    }
+
+    @Override
+    public void setQueryLock(QueryLockEnum queryLock) {
+
+    }
+
+    @Override
+    public QueryLockEnum getQueryLock() {
+        return QueryLockEnum.NONE;
     }
 
     @Override

--- a/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/ExpressionContext.java
+++ b/sql-core/src/main/java/com/easy/query/core/expression/sql/builder/ExpressionContext.java
@@ -7,6 +7,7 @@ import com.easy.query.core.expression.parser.core.available.RuntimeContextAvaila
 import com.easy.query.core.basic.extension.interceptor.Interceptor;
 import com.easy.query.core.basic.jdbc.executor.ResultColumnMetadata;
 import com.easy.query.core.enums.ExecuteMethodEnum;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.enums.SQLExecuteStrategyEnum;
 import com.easy.query.core.enums.sharding.ConnectionModeEnum;
 import com.easy.query.core.expression.builder.core.ValueFilter;
@@ -64,6 +65,8 @@ public interface ExpressionContext extends RuntimeContextAvailable {
    }
     void executeMethod(ExecuteMethodEnum executeMethod,boolean ifUnknown);
     ExecuteMethodEnum getExecuteMethod();
+    void setQueryLock(QueryLockEnum queryLock);
+    QueryLockEnum getQueryLock();
 
     void setMaxShardingQueryLimit(Integer maxShardingQueryLimit);
     Integer getMaxShardingQueryLimitOrNull();

--- a/sql-core/src/main/java/com/easy/query/core/expression/sql/expression/impl/QuerySQLExpressionImpl.java
+++ b/sql-core/src/main/java/com/easy/query/core/expression/sql/expression/impl/QuerySQLExpressionImpl.java
@@ -1,7 +1,10 @@
 package com.easy.query.core.expression.sql.expression.impl;
 
+import com.easy.query.core.basic.jdbc.conn.ConnectionManager;
 import com.easy.query.core.basic.jdbc.parameter.ToSQLContext;
+import com.easy.query.core.basic.jdbc.tx.Transaction;
 import com.easy.query.core.context.QueryRuntimeContext;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.expression.segment.builder.SQLBuilderSegment;
 import com.easy.query.core.expression.segment.condition.PredicateSegment;
 import com.easy.query.core.expression.sql.builder.ExpressionBuilder;
@@ -10,6 +13,8 @@ import com.easy.query.core.expression.sql.expression.EntityQuerySQLExpression;
 import com.easy.query.core.expression.sql.expression.EntityTableSQLExpression;
 import com.easy.query.core.expression.sql.expression.SQLExpression;
 import com.easy.query.core.expression.sql.expression.factory.ExpressionFactory;
+import com.easy.query.core.logging.Log;
+import com.easy.query.core.logging.LogFactory;
 import com.easy.query.core.util.EasyCollectionUtil;
 import com.easy.query.core.util.EasySQLExpressionUtil;
 import com.easy.query.core.util.EasySQLSegmentUtil;
@@ -25,6 +30,7 @@ import java.util.List;
  * @author xuejiaming
  */
 public class QuerySQLExpressionImpl implements EntityQuerySQLExpression {
+    private static final Log log = LogFactory.getLog(QuerySQLExpressionImpl.class);
 
     protected final EntitySQLExpressionMetadata entitySQLExpressionMetadata;
     protected SQLBuilderSegment projects;
@@ -224,7 +230,27 @@ public class QuerySQLExpressionImpl implements EntityQuerySQLExpression {
             }
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
+    }
+
+    protected String appendQueryLock(boolean root, String sql) {
+        if (!root) {
+            return sql;
+        }
+        if (entitySQLExpressionMetadata.getExpressionContext().getQueryLock() != QueryLockEnum.FOR_UPDATE) {
+            return sql;
+        }
+        ConnectionManager connectionManager = entitySQLExpressionMetadata.getRuntimeContext().getConnectionManager();
+        if (!connectionManager.currentThreadInTransaction()) {
+            throw new IllegalStateException("FOR UPDATE query requires an active transaction, please call beginTransaction() before executing this query.");
+        }
+        String forUpdateSQL = sql + " FOR UPDATE";
+        if (log.isDebugEnabled()) {
+            Transaction transaction = connectionManager.getTransactionOrNull();
+            String txId = transaction == null ? "env-tx" : String.valueOf(System.identityHashCode(transaction));
+            log.debug("FOR UPDATE SQL[txId=" + txId + "]: " + forUpdateSQL);
+        }
+        return forUpdateSQL;
     }
 
     protected void buildSQLTableOrJoin(StringBuilder sql, List<EntityTableSQLExpression> tables, ToSQLContext toSQLContext) {

--- a/sql-db-support/sql-clickhouse/src/main/java/com/easy/query/clickhouse/expression/ClickHouseQuerySQLExpression.java
+++ b/sql-db-support/sql-clickhouse/src/main/java/com/easy/query/clickhouse/expression/ClickHouseQuerySQLExpression.java
@@ -1,5 +1,6 @@
 package com.easy.query.clickhouse.expression;
 
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.expression.sql.expression.impl.EntitySQLExpressionMetadata;
 import com.easy.query.core.expression.sql.expression.impl.QuerySQLExpressionImpl;
 
@@ -12,5 +13,17 @@ import com.easy.query.core.expression.sql.expression.impl.QuerySQLExpressionImpl
 public class ClickHouseQuerySQLExpression extends QuerySQLExpressionImpl {
     public ClickHouseQuerySQLExpression(EntitySQLExpressionMetadata entitySQLExpressionMetadata) {
         super(entitySQLExpressionMetadata);
+    }
+
+    @Override
+    protected String appendQueryLock(boolean root, String sql) {
+        if (!root) {
+            return sql;
+        }
+        if (entitySQLExpressionMetadata.getExpressionContext().getQueryLock() != QueryLockEnum.FOR_UPDATE) {
+            return sql;
+        }
+        throw new UnsupportedOperationException("ClickHouse does not support FOR UPDATE row-level locking. " +
+                "ClickHouse is optimized for OLAP workloads and does not provide row-level locks.");
     }
 }

--- a/sql-db-support/sql-dameng/src/main/java/com/easy/query/dameng/expression/DamengQuerySQLExpression.java
+++ b/sql-db-support/sql-dameng/src/main/java/com/easy/query/dameng/expression/DamengQuerySQLExpression.java
@@ -50,7 +50,7 @@ public class DamengQuerySQLExpression extends QuerySQLExpressionImpl {
                 return sb.toString();
             }
         }
-        return toSQL0(true, toSQLContext);
+        return toSQL0(root, toSQLContext);
     }
 
     protected String toSQL0(boolean root, ToSQLContext toSQLContext) {
@@ -119,6 +119,6 @@ public class DamengQuerySQLExpression extends QuerySQLExpressionImpl {
             }
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
     }
 }

--- a/sql-db-support/sql-db2/src/main/java/com/easy/query/db2/expression/DB2QuerySQLExpression.java
+++ b/sql-db-support/sql-db2/src/main/java/com/easy/query/db2/expression/DB2QuerySQLExpression.java
@@ -111,7 +111,7 @@ public class DB2QuerySQLExpression extends QuerySQLExpressionImpl {
             sql.append(" FETCH FIRST ").append(rows).append(" ROWS ONLY");
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
     }
 
     protected SQLBuilderSegment getPrimaryKeyOrFirstColumnOrder(TableAvailable table) {

--- a/sql-db-support/sql-duckdb/src/main/java/com/easy/query/duckdb/expression/DuckDBSQLQuerySQLExpression.java
+++ b/sql-db-support/sql-duckdb/src/main/java/com/easy/query/duckdb/expression/DuckDBSQLQuerySQLExpression.java
@@ -1,5 +1,6 @@
 package com.easy.query.duckdb.expression;
 
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.expression.sql.expression.impl.EntitySQLExpressionMetadata;
 import com.easy.query.core.expression.sql.expression.impl.QuerySQLExpressionImpl;
 
@@ -14,4 +15,15 @@ public class DuckDBSQLQuerySQLExpression extends QuerySQLExpressionImpl {
         super(entitySQLExpressionMetadata);
     }
 
+    @Override
+    protected String appendQueryLock(boolean root, String sql) {
+        if (!root) {
+            return sql;
+        }
+        if (entitySQLExpressionMetadata.getExpressionContext().getQueryLock() != QueryLockEnum.FOR_UPDATE) {
+            return sql;
+        }
+        throw new UnsupportedOperationException("DuckDB does not support FOR UPDATE row-level locking. " +
+                "DuckDB is an analytical database and does not provide row-level locks.");
+    }
 }

--- a/sql-db-support/sql-mssql/src/main/java/com/easy/query/mssql/expression/MsSQLQuerySQLExpression.java
+++ b/sql-db-support/sql-mssql/src/main/java/com/easy/query/mssql/expression/MsSQLQuerySQLExpression.java
@@ -1,6 +1,7 @@
 package com.easy.query.mssql.expression;
 
 import com.easy.query.core.basic.jdbc.parameter.ToSQLContext;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.exception.EasyQueryInvalidOperationException;
 import com.easy.query.core.expression.parser.core.available.TableAvailable;
 import com.easy.query.core.expression.segment.Column2Segment;
@@ -118,7 +119,19 @@ public class MsSQLQuerySQLExpression extends QuerySQLExpressionImpl {
             }
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
+    }
+
+    @Override
+    protected String appendQueryLock(boolean root, String sql) {
+        if (!root) {
+            return sql;
+        }
+        if (entitySQLExpressionMetadata.getExpressionContext().getQueryLock() != QueryLockEnum.FOR_UPDATE) {
+            return sql;
+        }
+        throw new UnsupportedOperationException("SQL Server does not support FOR UPDATE syntax. " +
+                "Please use WITH (UPDLOCK, ROWLOCK) table hint instead, or consider using a different database dialect.");
     }
 
     protected SQLBuilderSegment getPrimaryKeyOrFirstColumnOrder(TableAvailable table) {

--- a/sql-db-support/sql-mssql/src/main/java/com/easy/query/mssql/expression/MsSQLRowNumberQuerySQLExpression.java
+++ b/sql-db-support/sql-mssql/src/main/java/com/easy/query/mssql/expression/MsSQLRowNumberQuerySQLExpression.java
@@ -128,6 +128,6 @@ public class MsSQLRowNumberQuerySQLExpression extends MsSQLQuerySQLExpression {
             }
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
     }
 }

--- a/sql-db-support/sql-oracle/src/main/java/com/easy/query/oracle/expression/OracleQuerySQLExpression.java
+++ b/sql-db-support/sql-oracle/src/main/java/com/easy/query/oracle/expression/OracleQuerySQLExpression.java
@@ -119,6 +119,6 @@ public class OracleQuerySQLExpression extends QuerySQLExpressionImpl {
             }
         }
 
-        return sql.toString();
+        return appendQueryLock(root, sql.toString());
     }
 }

--- a/sql-platform/sql-api-proxy/src/main/java/com/easy/query/api/proxy/entity/select/EntityQueryable.java
+++ b/sql-platform/sql-api-proxy/src/main/java/com/easy/query/api/proxy/entity/select/EntityQueryable.java
@@ -126,6 +126,18 @@ public interface EntityQueryable<T1Proxy extends ProxyEntity<T1Proxy, T1>, T1> e
     EntityQueryable<T1Proxy, T1> limit(boolean condition, long offset, long rows);
 
     /**
+     * Enable row-level lock query and append {@code FOR UPDATE} to SQL.
+     *
+     * <p>Requires an active transaction and supports only single-table query.</p>
+     *
+     * @return current queryable
+     */
+    @NotNull
+    default EntityQueryable<T1Proxy, T1> forUpdate() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * 先limit再select select selectExpression(*) from (select * from table limit x,y) t
      * @param offset
      * @param rows

--- a/sql-platform/sql-api-proxy/src/main/java/com/easy/query/api/proxy/entity/select/abstraction/AbstractEntityQueryable.java
+++ b/sql-platform/sql-api-proxy/src/main/java/com/easy/query/api/proxy/entity/select/abstraction/AbstractEntityQueryable.java
@@ -850,6 +850,13 @@ public abstract class AbstractEntityQueryable<T1Proxy extends ProxyEntity<T1Prox
         return this;
     }
 
+    @NotNull
+    @Override
+    public EntityQueryable<T1Proxy, T1> forUpdate() {
+        clientQueryable.forUpdate();
+        return this;
+    }
+
     @Override
     public EntityQueryable<T1Proxy, T1> asTable(Function<String, String> tableNameAs) {
         clientQueryable.asTable(tableNameAs);

--- a/sql-test/pom.xml
+++ b/sql-test/pom.xml
@@ -115,6 +115,18 @@
         </dependency>
         <dependency>
             <groupId>com.easy-query</groupId>
+            <artifactId>sql-db2</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.easy-query</groupId>
+            <artifactId>sql-gauss-db</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.easy-query</groupId>
             <artifactId>sql-api-proxy</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/sql-test/src/main/java/com/easy/query/test/ForUpdateDialectToSQLSmokeTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/ForUpdateDialectToSQLSmokeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  * create time 2026/3/6 00:00
  * 文件说明
  *
- * @author xuejiaming
+ * @author WCPE
  */
 public class ForUpdateDialectToSQLSmokeTest {
     @Before

--- a/sql-test/src/main/java/com/easy/query/test/ForUpdateDialectToSQLSmokeTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/ForUpdateDialectToSQLSmokeTest.java
@@ -1,0 +1,280 @@
+package com.easy.query.test;
+
+import com.easy.query.api.proxy.client.DefaultEasyEntityQuery;
+import com.easy.query.api.proxy.client.EasyEntityQuery;
+import com.easy.query.core.api.client.EasyQueryClient;
+import com.easy.query.core.basic.jdbc.tx.Transaction;
+import com.easy.query.core.bootstrapper.DatabaseConfiguration;
+import com.easy.query.core.bootstrapper.EasyQueryBootstrapper;
+import com.easy.query.core.logging.LogFactory;
+import com.easy.query.clickhouse.config.ClickHouseDatabaseConfiguration;
+import com.easy.query.dameng.config.DamengDatabaseConfiguration;
+import com.easy.query.db2.config.DB2DatabaseConfiguration;
+import com.easy.query.duckdb.config.DuckDBSQLDatabaseConfiguration;
+import com.easy.query.gauss.db.config.GaussDBDatabaseConfiguration;
+import com.easy.query.h2.config.H2DatabaseConfiguration;
+import com.easy.query.kingbase.es.config.KingbaseESDatabaseConfiguration;
+import com.easy.query.mssql.config.MsSQLDatabaseConfiguration;
+import com.easy.query.mssql.config.MsSQLRowNumberDatabaseConfiguration;
+import com.easy.query.mysql.config.MySQLDatabaseConfiguration;
+import com.easy.query.oracle.config.OracleDatabaseConfiguration;
+import com.easy.query.pgsql.config.PgSQLDatabaseConfiguration;
+import com.easy.query.sqlite.config.SQLiteDatabaseConfiguration;
+import com.easy.query.test.common.EmptyDataSource;
+import com.easy.query.test.doc.entity.DocBankCard;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * create time 2026/3/6 00:00
+ * 文件说明
+ *
+ * @author xuejiaming
+ */
+public class ForUpdateDialectToSQLSmokeTest {
+    @Before
+    public void before() {
+        LogFactory.useStdOutLogging();
+    }
+
+    private EasyEntityQuery create(DatabaseConfiguration databaseConfiguration) {
+        EasyQueryClient easyQueryClient = EasyQueryBootstrapper.defaultBuilderConfiguration()
+                .setDefaultDataSource(new EmptyDataSource())
+                .optionConfigure(op -> op.setDeleteThrowError(false))
+                .useDatabaseConfigure(databaseConfiguration)
+                .build();
+        return new DefaultEasyEntityQuery(easyQueryClient);
+    }
+
+    // ==================== Supported Dialects ====================
+
+    @Test
+    public void mysqlForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new MySQLDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void pgsqlForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new PgSQLDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void h2ForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new H2DatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void sqliteForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new SQLiteDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void kingbaseESForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new KingbaseESDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void gaussDBForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new GaussDBDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void damengForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new DamengDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.toUpperCase().contains("ROWNUM"));
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void oracleForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new OracleDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.toUpperCase().contains("ROWNUM"));
+            Assert.assertTrue(sql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void db2ForUpdateToSQLSmoke() {
+        EasyEntityQuery easyEntityQuery = create(new DB2DatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String sql = easyEntityQuery.queryable(DocBankCard.class)
+                    .where(card -> card.id().isNotNull())
+                    .orderBy(card -> card.id().asc())
+                    .limit(1, 2)
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(sql.toUpperCase().contains("OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(sql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    // ==================== Unsupported Dialects (should throw UnsupportedOperationException) ====================
+
+    @Test
+    public void msSQLForUpdateThrowsUnsupported() {
+        EasyEntityQuery easyEntityQuery = create(new MsSQLDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(DocBankCard.class)
+                        .where(card -> card.id().isNotNull())
+                        .forUpdate()
+                        .toSQL();
+                Assert.fail("MsSQL should throw UnsupportedOperationException for FOR UPDATE");
+            } catch (UnsupportedOperationException ex) {
+                Assert.assertTrue(ex.getMessage().contains("SQL Server does not support FOR UPDATE"));
+            }
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void msSQLRowNumberForUpdateThrowsUnsupported() {
+        EasyEntityQuery easyEntityQuery = create(new MsSQLRowNumberDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(DocBankCard.class)
+                        .where(card -> card.id().isNotNull())
+                        .forUpdate()
+                        .toSQL();
+                Assert.fail("MsSQL RowNumber should throw UnsupportedOperationException for FOR UPDATE");
+            } catch (UnsupportedOperationException ex) {
+                Assert.assertTrue(ex.getMessage().contains("SQL Server does not support FOR UPDATE"));
+            }
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void clickHouseForUpdateThrowsUnsupported() {
+        EasyEntityQuery easyEntityQuery = create(new ClickHouseDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(DocBankCard.class)
+                        .where(card -> card.id().isNotNull())
+                        .forUpdate()
+                        .toSQL();
+                Assert.fail("ClickHouse should throw UnsupportedOperationException for FOR UPDATE");
+            } catch (UnsupportedOperationException ex) {
+                Assert.assertTrue(ex.getMessage().contains("ClickHouse does not support FOR UPDATE"));
+            }
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void duckDBForUpdateThrowsUnsupported() {
+        EasyEntityQuery easyEntityQuery = create(new DuckDBSQLDatabaseConfiguration());
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(DocBankCard.class)
+                        .where(card -> card.id().isNotNull())
+                        .forUpdate()
+                        .toSQL();
+                Assert.fail("DuckDB should throw UnsupportedOperationException for FOR UPDATE");
+            } catch (UnsupportedOperationException ex) {
+                Assert.assertTrue(ex.getMessage().contains("DuckDB does not support FOR UPDATE"));
+            }
+            transaction.commit();
+        }
+    }
+
+    private static int countMatches(String text, String part) {
+        int count = 0;
+        int index = 0;
+        while (index >= 0) {
+            index = text.indexOf(part, index);
+            if (index >= 0) {
+                count++;
+                index += part.length();
+            }
+        }
+        return count;
+    }
+}

--- a/sql-test/src/main/java/com/easy/query/test/GenericTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/GenericTest.java
@@ -14,6 +14,7 @@ import com.easy.query.core.configuration.nameconversion.impl.UpperUnderlinedName
 import com.easy.query.core.enums.ContextTypeEnum;
 import com.easy.query.core.enums.EasyBehaviorEnum;
 import com.easy.query.core.enums.ExecuteMethodEnum;
+import com.easy.query.core.enums.QueryLockEnum;
 import com.easy.query.core.enums.SQLExecuteStrategyEnum;
 import com.easy.query.core.enums.SQLRangeEnum;
 import com.easy.query.core.exception.EasyQueryException;
@@ -1261,6 +1262,23 @@ public class GenericTest extends BaseTest {
         ExpressionContext expressionContext = easyExpressionContext.cloneExpressionContext();
         Assert.assertNull(expressionContext.getPrintSQL());
         Assert.assertEquals(true, expressionContext.getPrintNavSQL());
+    }
+
+    @Test
+    public void testQueryLockClonePropagation() {
+        EasyExpressionContext easyExpressionContext = new EasyExpressionContext(easyEntityQuery.getRuntimeContext(), ContextTypeEnum.QUERY);
+        easyExpressionContext.setQueryLock(QueryLockEnum.FOR_UPDATE);
+        ExpressionContext expressionContext = easyExpressionContext.cloneExpressionContext();
+        Assert.assertEquals(QueryLockEnum.FOR_UPDATE, expressionContext.getQueryLock());
+    }
+
+    @Test
+    public void testQueryLockExtendFromPropagation() {
+        EasyExpressionContext sourceExpressionContext = new EasyExpressionContext(easyEntityQuery.getRuntimeContext(), ContextTypeEnum.QUERY);
+        sourceExpressionContext.setQueryLock(QueryLockEnum.FOR_UPDATE);
+        EasyExpressionContext targetExpressionContext = new EasyExpressionContext(easyEntityQuery.getRuntimeContext(), ContextTypeEnum.QUERY);
+        sourceExpressionContext.extendFrom(targetExpressionContext);
+        Assert.assertEquals(QueryLockEnum.FOR_UPDATE, targetExpressionContext.getQueryLock());
     }
 
     @Test

--- a/sql-test/src/main/java/com/easy/query/test/dameng/DamengForUpdateTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/dameng/DamengForUpdateTest.java
@@ -1,4 +1,4 @@
-package com.easy.query.test.mysql8;
+package com.easy.query.test.dameng;
 
 import com.easy.query.api.proxy.entity.select.EntityQueryable;
 import com.easy.query.core.basic.api.select.Query;
@@ -16,19 +16,19 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * create time 2026/3/5 19:00
- * 文件说明
+ * create time 2026/3/10
+ * Dameng FOR UPDATE integration tests
  *
  * @author WCPE
  */
-public class ForUpdateTest extends BaseTest {
+public class DamengForUpdateTest extends DamengBaseTest {
 
     @Test
     public void testForUpdateSqlAppendInTransaction() {
         ListenerContext listenerContext = new ListenerContext();
         listenerContextManager.startListen(listenerContext);
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            easyEntityQuery.queryable(SysUser.class)
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            entityQuery.queryable(SysUser.class)
                     .where(user -> user.id().eq("u1"))
                     .forUpdate()
                     .firstOrNull();
@@ -44,7 +44,7 @@ public class ForUpdateTest extends BaseTest {
     @Test
     public void testForUpdateWithoutTransactionThrows() {
         try {
-            easyEntityQuery.queryable(SysUser.class)
+            entityQuery.queryable(SysUser.class)
                     .where(user -> user.id().eq("u1"))
                     .forUpdate();
             Assert.fail("forUpdate should require active transaction");
@@ -55,9 +55,9 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateJoinNotSupported() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+        try (Transaction transaction = entityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
+                entityQuery.queryable(SysUser.class)
                         .leftJoin(SysBankCard.class, (user, card) -> user.id().eq(card.uid()))
                         .forUpdate();
                 Assert.fail("forUpdate should reject join query");
@@ -70,9 +70,9 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateDuplicateCallThrows() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+        try (Transaction transaction = entityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
+                entityQuery.queryable(SysUser.class)
                         .where(user -> user.id().eq("u1"))
                         .forUpdate()
                         .forUpdate();
@@ -93,8 +93,8 @@ public class ForUpdateTest extends BaseTest {
         AtomicReference<Throwable> error = new AtomicReference<>();
 
         Thread firstThread = new Thread(() -> {
-            try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                easyEntityQuery.queryable(SysUser.class)
+            try (Transaction transaction = entityQuery.beginTransaction()) {
+                entityQuery.queryable(SysUser.class)
                         .where(user -> user.id().eq("u1"))
                         .forUpdate()
                         .firstOrNull();
@@ -107,7 +107,7 @@ public class ForUpdateTest extends BaseTest {
                 error.compareAndSet(null, ex);
                 releaseFirst.countDown();
             }
-        }, "for-update-first-thread");
+        }, "dameng-for-update-first-thread");
 
         Thread secondThread = new Thread(() -> {
             try {
@@ -115,8 +115,8 @@ public class ForUpdateTest extends BaseTest {
                     throw new IllegalStateException("second transaction did not observe first lock");
                 }
                 long start = System.currentTimeMillis();
-                try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                    easyEntityQuery.queryable(SysUser.class)
+                try (Transaction transaction = entityQuery.beginTransaction()) {
+                    entityQuery.queryable(SysUser.class)
                             .where(user -> user.id().eq("u1"))
                             .forUpdate()
                             .firstOrNull();
@@ -128,7 +128,7 @@ public class ForUpdateTest extends BaseTest {
             } finally {
                 secondFinished.countDown();
             }
-        }, "for-update-second-thread");
+        }, "dameng-for-update-second-thread");
 
         firstThread.start();
         secondThread.start();
@@ -147,8 +147,8 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateAppliesOnlyOnOuterQueryForExistsAndInSubQuery() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            String existsSql = easyEntityQuery.queryable(SysUser.class)
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            String existsSql = entityQuery.queryable(SysUser.class)
                     .where(user -> {
                         user.expression().exists(
                                 user.expression().subQueryable(SysBankCard.class)
@@ -160,9 +160,9 @@ public class ForUpdateTest extends BaseTest {
             Assert.assertTrue(existsSql.endsWith(" FOR UPDATE"));
             Assert.assertEquals(1, countMatches(existsSql, "FOR UPDATE"));
 
-            Query<String> uidSubQuery = easyEntityQuery.queryable(SysBankCard.class)
+            Query<String> uidSubQuery = entityQuery.queryable(SysBankCard.class)
                     .selectColumn(bankCard -> bankCard.uid());
-            String inSql = easyEntityQuery.queryable(SysUser.class)
+            String inSql = entityQuery.queryable(SysUser.class)
                     .where(user -> user.id().in(uidSubQuery))
                     .forUpdate()
                     .toSQL();
@@ -174,8 +174,8 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateDerivedCountAndExistsSqlBehaviorConsistent() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            EntityQueryable<?, SysUser> forUpdateQueryable = easyEntityQuery.queryable(SysUser.class)
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            EntityQueryable<?, SysUser> forUpdateQueryable = entityQuery.queryable(SysUser.class)
                     .where(user -> user.id().eq("u1"))
                     .forUpdate();
 

--- a/sql-test/src/main/java/com/easy/query/test/h2/H2ForUpdateTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/h2/H2ForUpdateTest.java
@@ -1,12 +1,12 @@
-package com.easy.query.test.mysql8;
+package com.easy.query.test.h2;
 
 import com.easy.query.api.proxy.entity.select.EntityQueryable;
 import com.easy.query.core.basic.api.select.Query;
 import com.easy.query.core.basic.extension.listener.JdbcExecuteAfterArg;
 import com.easy.query.core.basic.jdbc.tx.Transaction;
+import com.easy.query.test.h2.domain.DefTable;
+import com.easy.query.test.h2.domain.DefTableLeft1;
 import com.easy.query.test.listener.ListenerContext;
-import com.easy.query.test.mysql8.entity.bank.SysBankCard;
-import com.easy.query.test.mysql8.entity.bank.SysUser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,20 +16,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * create time 2026/3/5 19:00
- * 文件说明
+ * create time 2026/3/10
+ * H2 FOR UPDATE integration tests
  *
  * @author WCPE
  */
-public class ForUpdateTest extends BaseTest {
+public class H2ForUpdateTest extends H2BaseTest {
 
     @Test
     public void testForUpdateSqlAppendInTransaction() {
         ListenerContext listenerContext = new ListenerContext();
         listenerContextManager.startListen(listenerContext);
         try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+            easyEntityQuery.queryable(DefTable.class)
+                    .where(table -> table.id().eq("0"))
                     .forUpdate()
                     .firstOrNull();
             transaction.commit();
@@ -44,8 +44,8 @@ public class ForUpdateTest extends BaseTest {
     @Test
     public void testForUpdateWithoutTransactionThrows() {
         try {
-            easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+            easyEntityQuery.queryable(DefTable.class)
+                    .where(table -> table.id().eq("0"))
                     .forUpdate();
             Assert.fail("forUpdate should require active transaction");
         } catch (IllegalStateException ex) {
@@ -57,8 +57,8 @@ public class ForUpdateTest extends BaseTest {
     public void testForUpdateJoinNotSupported() {
         try (Transaction transaction = easyEntityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
-                        .leftJoin(SysBankCard.class, (user, card) -> user.id().eq(card.uid()))
+                easyEntityQuery.queryable(DefTable.class)
+                        .leftJoin(DefTableLeft1.class, (table, left1) -> table.id().eq(left1.defId()))
                         .forUpdate();
                 Assert.fail("forUpdate should reject join query");
             } catch (IllegalStateException ex) {
@@ -72,8 +72,8 @@ public class ForUpdateTest extends BaseTest {
     public void testForUpdateDuplicateCallThrows() {
         try (Transaction transaction = easyEntityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
-                        .where(user -> user.id().eq("u1"))
+                easyEntityQuery.queryable(DefTable.class)
+                        .where(table -> table.id().eq("0"))
                         .forUpdate()
                         .forUpdate();
                 Assert.fail("repeated forUpdate should be rejected");
@@ -94,8 +94,8 @@ public class ForUpdateTest extends BaseTest {
 
         Thread firstThread = new Thread(() -> {
             try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                easyEntityQuery.queryable(SysUser.class)
-                        .where(user -> user.id().eq("u1"))
+                easyEntityQuery.queryable(DefTable.class)
+                        .where(table -> table.id().eq("0"))
                         .forUpdate()
                         .firstOrNull();
                 firstLocked.countDown();
@@ -107,7 +107,7 @@ public class ForUpdateTest extends BaseTest {
                 error.compareAndSet(null, ex);
                 releaseFirst.countDown();
             }
-        }, "for-update-first-thread");
+        }, "h2-for-update-first-thread");
 
         Thread secondThread = new Thread(() -> {
             try {
@@ -116,8 +116,8 @@ public class ForUpdateTest extends BaseTest {
                 }
                 long start = System.currentTimeMillis();
                 try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                    easyEntityQuery.queryable(SysUser.class)
-                            .where(user -> user.id().eq("u1"))
+                    easyEntityQuery.queryable(DefTable.class)
+                            .where(table -> table.id().eq("0"))
                             .forUpdate()
                             .firstOrNull();
                     transaction.commit();
@@ -128,7 +128,7 @@ public class ForUpdateTest extends BaseTest {
             } finally {
                 secondFinished.countDown();
             }
-        }, "for-update-second-thread");
+        }, "h2-for-update-second-thread");
 
         firstThread.start();
         secondThread.start();
@@ -148,11 +148,11 @@ public class ForUpdateTest extends BaseTest {
     @Test
     public void testForUpdateAppliesOnlyOnOuterQueryForExistsAndInSubQuery() {
         try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            String existsSql = easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> {
-                        user.expression().exists(
-                                user.expression().subQueryable(SysBankCard.class)
-                                        .where(bankCard -> bankCard.uid().eq(user.id()))
+            String existsSql = easyEntityQuery.queryable(DefTable.class)
+                    .where(table -> {
+                        table.expression().exists(
+                                table.expression().subQueryable(DefTableLeft1.class)
+                                        .where(left1 -> left1.defId().eq(table.id()))
                         );
                     })
                     .forUpdate()
@@ -160,10 +160,10 @@ public class ForUpdateTest extends BaseTest {
             Assert.assertTrue(existsSql.endsWith(" FOR UPDATE"));
             Assert.assertEquals(1, countMatches(existsSql, "FOR UPDATE"));
 
-            Query<String> uidSubQuery = easyEntityQuery.queryable(SysBankCard.class)
-                    .selectColumn(bankCard -> bankCard.uid());
-            String inSql = easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().in(uidSubQuery))
+            Query<String> defIdSubQuery = easyEntityQuery.queryable(DefTableLeft1.class)
+                    .selectColumn(left1 -> left1.defId());
+            String inSql = easyEntityQuery.queryable(DefTable.class)
+                    .where(table -> table.id().in(defIdSubQuery))
                     .forUpdate()
                     .toSQL();
             Assert.assertTrue(inSql.endsWith(" FOR UPDATE"));
@@ -175,8 +175,8 @@ public class ForUpdateTest extends BaseTest {
     @Test
     public void testForUpdateDerivedCountAndExistsSqlBehaviorConsistent() {
         try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            EntityQueryable<?, SysUser> forUpdateQueryable = easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+            EntityQueryable<?, DefTable> forUpdateQueryable = easyEntityQuery.queryable(DefTable.class)
+                    .where(table -> table.id().eq("0"))
                     .forUpdate();
 
             String countSql = forUpdateQueryable.cloneQueryable()

--- a/sql-test/src/main/java/com/easy/query/test/mysql8/ForUpdateTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/mysql8/ForUpdateTest.java
@@ -1,0 +1,210 @@
+package com.easy.query.test.mysql8;
+
+import com.easy.query.api.proxy.entity.select.EntityQueryable;
+import com.easy.query.core.basic.api.select.Query;
+import com.easy.query.core.basic.extension.listener.JdbcExecuteAfterArg;
+import com.easy.query.core.basic.jdbc.tx.Transaction;
+import com.easy.query.test.listener.ListenerContext;
+import com.easy.query.test.mysql8.entity.bank.SysBankCard;
+import com.easy.query.test.mysql8.entity.bank.SysUser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * create time 2026/3/5 19:00
+ * 文件说明
+ *
+ * @author xuejiaming
+ */
+public class ForUpdateTest extends BaseTest {
+
+    @Test
+    public void testForUpdateSqlAppendInTransaction() {
+        ListenerContext listenerContext = new ListenerContext();
+        listenerContextManager.startListen(listenerContext);
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            easyEntityQuery.queryable(SysUser.class)
+                    .where(user -> user.id().eq("u1"))
+                    .forUpdate()
+                    .firstOrNull();
+            transaction.commit();
+        } finally {
+            listenerContextManager.clear();
+        }
+        JdbcExecuteAfterArg jdbcExecuteAfterArg = listenerContext.getJdbcExecuteAfterArg();
+        Assert.assertNotNull(jdbcExecuteAfterArg);
+        Assert.assertTrue(jdbcExecuteAfterArg.getBeforeArg().getSql().endsWith(" FOR UPDATE"));
+    }
+
+    @Test
+    public void testForUpdateWithoutTransactionThrows() {
+        try {
+            easyEntityQuery.queryable(SysUser.class)
+                    .where(user -> user.id().eq("u1"))
+                    .forUpdate();
+            Assert.fail("forUpdate should require active transaction");
+        } catch (IllegalStateException ex) {
+            Assert.assertTrue(ex.getMessage().contains("beginTransaction"));
+        }
+    }
+
+    @Test
+    public void testForUpdateJoinNotSupported() {
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(SysUser.class)
+                        .leftJoin(SysBankCard.class, (user, card) -> user.id().eq(card.uid()))
+                        .forUpdate();
+                Assert.fail("forUpdate should reject join query");
+            } catch (IllegalStateException ex) {
+                Assert.assertTrue(ex.getMessage().contains("single-table"));
+            }
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void testForUpdateDuplicateCallThrows() {
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            try {
+                easyEntityQuery.queryable(SysUser.class)
+                        .where(user -> user.id().eq("u1"))
+                        .forUpdate()
+                        .forUpdate();
+                Assert.fail("repeated forUpdate should be rejected");
+            } catch (IllegalStateException ex) {
+                Assert.assertTrue(ex.getMessage().contains("repeated"));
+            }
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void testForUpdateBlocksConcurrentTransaction() throws InterruptedException {
+        CountDownLatch firstLocked = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch secondFinished = new CountDownLatch(1);
+        AtomicLong secondWaitMillis = new AtomicLong(0L);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        Thread firstThread = new Thread(() -> {
+            try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+                easyEntityQuery.queryable(SysUser.class)
+                        .where(user -> user.id().eq("u1"))
+                        .forUpdate()
+                        .firstOrNull();
+                firstLocked.countDown();
+                if (!releaseFirst.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("first transaction wait timeout");
+                }
+                transaction.commit();
+            } catch (Throwable ex) {
+                error.compareAndSet(null, ex);
+                releaseFirst.countDown();
+            }
+        }, "for-update-first-thread");
+
+        Thread secondThread = new Thread(() -> {
+            try {
+                if (!firstLocked.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("second transaction did not observe first lock");
+                }
+                long start = System.currentTimeMillis();
+                try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+                    easyEntityQuery.queryable(SysUser.class)
+                            .where(user -> user.id().eq("u1"))
+                            .forUpdate()
+                            .firstOrNull();
+                    transaction.commit();
+                }
+                secondWaitMillis.set(System.currentTimeMillis() - start);
+            } catch (Throwable ex) {
+                error.compareAndSet(null, ex);
+            } finally {
+                secondFinished.countDown();
+            }
+        }, "for-update-second-thread");
+
+        firstThread.start();
+        secondThread.start();
+        Assert.assertTrue("first transaction failed to lock row in time", firstLocked.await(5, TimeUnit.SECONDS));
+        Thread.sleep(300);
+        Assert.assertEquals("second transaction should still be blocked by row lock", 1L, secondFinished.getCount());
+        releaseFirst.countDown();
+        Assert.assertTrue("second transaction did not finish in time", secondFinished.await(5, TimeUnit.SECONDS));
+        firstThread.join();
+        secondThread.join();
+        if (error.get() != null) {
+            throw new AssertionError(error.get());
+        }
+        Assert.assertTrue("second transaction should wait for lock release", secondWaitMillis.get() >= 250L);
+    }
+
+    @Test
+    public void testForUpdateAppliesOnlyOnOuterQueryForExistsAndInSubQuery() {
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            String existsSql = easyEntityQuery.queryable(SysUser.class)
+                    .where(user -> {
+                        user.expression().exists(
+                                user.expression().subQueryable(SysBankCard.class)
+                                        .where(bankCard -> bankCard.uid().eq(user.id()))
+                        );
+                    })
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(existsSql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(existsSql, "FOR UPDATE"));
+
+            Query<String> uidSubQuery = easyEntityQuery.queryable(SysBankCard.class)
+                    .selectColumn(bankCard -> bankCard.uid());
+            String inSql = easyEntityQuery.queryable(SysUser.class)
+                    .where(user -> user.id().in(uidSubQuery))
+                    .forUpdate()
+                    .toSQL();
+            Assert.assertTrue(inSql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(inSql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void testForUpdateDerivedCountAndExistsSqlBehaviorConsistent() {
+        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+            EntityQueryable<?, SysUser> forUpdateQueryable = easyEntityQuery.queryable(SysUser.class)
+                    .where(user -> user.id().eq("u1"))
+                    .forUpdate();
+
+            String countSql = forUpdateQueryable.cloneQueryable()
+                    .selectCount()
+                    .toSQL();
+            String existsSql = forUpdateQueryable.cloneQueryable()
+                    .limit(1)
+                    .select(" 1 ")
+                    .toSQL();
+
+            Assert.assertTrue(countSql.endsWith(" FOR UPDATE"));
+            Assert.assertTrue(existsSql.endsWith(" FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(countSql, "FOR UPDATE"));
+            Assert.assertEquals(1, countMatches(existsSql, "FOR UPDATE"));
+            transaction.commit();
+        }
+    }
+
+    private static int countMatches(String text, String part) {
+        int count = 0;
+        int index = 0;
+        while (index >= 0) {
+            index = text.indexOf(part, index);
+            if (index >= 0) {
+                count++;
+                index += part.length();
+            }
+        }
+        return count;
+    }
+}

--- a/sql-test/src/main/java/com/easy/query/test/pgsql/PgSQLForUpdateTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/pgsql/PgSQLForUpdateTest.java
@@ -1,12 +1,12 @@
-package com.easy.query.test.mysql8;
+package com.easy.query.test.pgsql;
 
 import com.easy.query.api.proxy.entity.select.EntityQueryable;
 import com.easy.query.core.basic.api.select.Query;
 import com.easy.query.core.basic.extension.listener.JdbcExecuteAfterArg;
 import com.easy.query.core.basic.jdbc.tx.Transaction;
+import com.easy.query.test.doc.entity.DocBankCard;
+import com.easy.query.test.doc.entity.DocUser;
 import com.easy.query.test.listener.ListenerContext;
-import com.easy.query.test.mysql8.entity.bank.SysBankCard;
-import com.easy.query.test.mysql8.entity.bank.SysUser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,20 +16,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * create time 2026/3/5 19:00
- * 文件说明
+ * create time 2026/3/10
+ * PostgreSQL FOR UPDATE integration tests
  *
  * @author WCPE
  */
-public class ForUpdateTest extends BaseTest {
+public class PgSQLForUpdateTest extends PgSQLBaseTest {
 
     @Test
     public void testForUpdateSqlAppendInTransaction() {
         ListenerContext listenerContext = new ListenerContext();
         listenerContextManager.startListen(listenerContext);
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            entityQuery.queryable(DocUser.class)
+                    .where(user -> user.id().eq("小明id"))
                     .forUpdate()
                     .firstOrNull();
             transaction.commit();
@@ -44,8 +44,8 @@ public class ForUpdateTest extends BaseTest {
     @Test
     public void testForUpdateWithoutTransactionThrows() {
         try {
-            easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+            entityQuery.queryable(DocUser.class)
+                    .where(user -> user.id().eq("小明id"))
                     .forUpdate();
             Assert.fail("forUpdate should require active transaction");
         } catch (IllegalStateException ex) {
@@ -55,10 +55,10 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateJoinNotSupported() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+        try (Transaction transaction = entityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
-                        .leftJoin(SysBankCard.class, (user, card) -> user.id().eq(card.uid()))
+                entityQuery.queryable(DocUser.class)
+                        .leftJoin(DocBankCard.class, (user, card) -> user.id().eq(card.uid()))
                         .forUpdate();
                 Assert.fail("forUpdate should reject join query");
             } catch (IllegalStateException ex) {
@@ -70,10 +70,10 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateDuplicateCallThrows() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
+        try (Transaction transaction = entityQuery.beginTransaction()) {
             try {
-                easyEntityQuery.queryable(SysUser.class)
-                        .where(user -> user.id().eq("u1"))
+                entityQuery.queryable(DocUser.class)
+                        .where(user -> user.id().eq("小明id"))
                         .forUpdate()
                         .forUpdate();
                 Assert.fail("repeated forUpdate should be rejected");
@@ -93,9 +93,9 @@ public class ForUpdateTest extends BaseTest {
         AtomicReference<Throwable> error = new AtomicReference<>();
 
         Thread firstThread = new Thread(() -> {
-            try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                easyEntityQuery.queryable(SysUser.class)
-                        .where(user -> user.id().eq("u1"))
+            try (Transaction transaction = entityQuery.beginTransaction()) {
+                entityQuery.queryable(DocUser.class)
+                        .where(user -> user.id().eq("小明id"))
                         .forUpdate()
                         .firstOrNull();
                 firstLocked.countDown();
@@ -107,7 +107,7 @@ public class ForUpdateTest extends BaseTest {
                 error.compareAndSet(null, ex);
                 releaseFirst.countDown();
             }
-        }, "for-update-first-thread");
+        }, "pg-for-update-first-thread");
 
         Thread secondThread = new Thread(() -> {
             try {
@@ -115,9 +115,9 @@ public class ForUpdateTest extends BaseTest {
                     throw new IllegalStateException("second transaction did not observe first lock");
                 }
                 long start = System.currentTimeMillis();
-                try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-                    easyEntityQuery.queryable(SysUser.class)
-                            .where(user -> user.id().eq("u1"))
+                try (Transaction transaction = entityQuery.beginTransaction()) {
+                    entityQuery.queryable(DocUser.class)
+                            .where(user -> user.id().eq("小明id"))
                             .forUpdate()
                             .firstOrNull();
                     transaction.commit();
@@ -128,7 +128,7 @@ public class ForUpdateTest extends BaseTest {
             } finally {
                 secondFinished.countDown();
             }
-        }, "for-update-second-thread");
+        }, "pg-for-update-second-thread");
 
         firstThread.start();
         secondThread.start();
@@ -147,11 +147,11 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateAppliesOnlyOnOuterQueryForExistsAndInSubQuery() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            String existsSql = easyEntityQuery.queryable(SysUser.class)
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            String existsSql = entityQuery.queryable(DocUser.class)
                     .where(user -> {
                         user.expression().exists(
-                                user.expression().subQueryable(SysBankCard.class)
+                                user.expression().subQueryable(DocBankCard.class)
                                         .where(bankCard -> bankCard.uid().eq(user.id()))
                         );
                     })
@@ -160,9 +160,9 @@ public class ForUpdateTest extends BaseTest {
             Assert.assertTrue(existsSql.endsWith(" FOR UPDATE"));
             Assert.assertEquals(1, countMatches(existsSql, "FOR UPDATE"));
 
-            Query<String> uidSubQuery = easyEntityQuery.queryable(SysBankCard.class)
+            Query<String> uidSubQuery = entityQuery.queryable(DocBankCard.class)
                     .selectColumn(bankCard -> bankCard.uid());
-            String inSql = easyEntityQuery.queryable(SysUser.class)
+            String inSql = entityQuery.queryable(DocUser.class)
                     .where(user -> user.id().in(uidSubQuery))
                     .forUpdate()
                     .toSQL();
@@ -174,9 +174,9 @@ public class ForUpdateTest extends BaseTest {
 
     @Test
     public void testForUpdateDerivedCountAndExistsSqlBehaviorConsistent() {
-        try (Transaction transaction = easyEntityQuery.beginTransaction()) {
-            EntityQueryable<?, SysUser> forUpdateQueryable = easyEntityQuery.queryable(SysUser.class)
-                    .where(user -> user.id().eq("u1"))
+        try (Transaction transaction = entityQuery.beginTransaction()) {
+            EntityQueryable<?, DocUser> forUpdateQueryable = entityQuery.queryable(DocUser.class)
+                    .where(user -> user.id().eq("小明id"))
                     .forUpdate();
 
             String countSql = forUpdateQueryable.cloneQueryable()


### PR DESCRIPTION
# FOR UPDATE 支持情况汇总

| 数据库 | 支持 | 实现方式 |
|--------|:----:|----------|
| MySQL | ✅ | 继承基类 |
| PostgreSQL | ✅ | 继承基类 |
| H2 | ✅ | 继承基类 |
| SQLite | ✅ | 继承基类 |
| KingbaseES | ✅ | 继承基类 |
| GaussDB | ✅ | 继承基类 |
| Dameng | ✅ | 自定义 appendQueryLock() |
| Oracle | ✅ | 自定义 appendQueryLock() |
| DB2 | ✅ | 自定义 appendQueryLock() |
| MsSQL | ❌ | 抛出 UnsupportedOperationException |
| ClickHouse | ❌ | 抛出 UnsupportedOperationException |
| DuckDB | ❌ | 抛出 UnsupportedOperationException |