### PR TITLE
feat: support TDengine STable/TAGS and 3.0 syntax adaptation

### DIFF
--- a/sql-core/src/main/java/com/easy/query/core/annotation/Column.java
+++ b/sql-core/src/main/java/com/easy/query/core/annotation/Column.java
@@ -182,5 +182,12 @@ public @interface Column {
     int scale() default 0;
 
     ColumnSQLExpression sqlExpression() default @ColumnSQLExpression(sql = "",  args = {});
+
     JDBCType jdbcType() default JDBCType.OTHER;
+    /**
+     * 是否是标签
+     * 仅迁移时生效,目前仅tsdb支持该属性
+     * @return
+     */
+    boolean tag() default false;
 }

--- a/sql-core/src/main/java/com/easy/query/core/basic/jdbc/executor/internal/merge/result/impl/EasyShardingStreamResultSet.java
+++ b/sql-core/src/main/java/com/easy/query/core/basic/jdbc/executor/internal/merge/result/impl/EasyShardingStreamResultSet.java
@@ -11,11 +11,11 @@ import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 
@@ -28,15 +28,15 @@ import java.sql.Timestamp;
 public final class EasyShardingStreamResultSet implements ShardingStreamResultSet, JdbcShardingStreamResultSet {
     private static final Log log= LogFactory.getLog(EasyShardingStreamResultSet.class);
     private final ResultSet resultSet;
-    private final PreparedStatement preparedStatement;
+    private final Statement statement;
     private boolean hasElement;
     private  boolean skipFirst;
     private boolean closed=false;
 
-    public EasyShardingStreamResultSet(ResultSet resultSet, PreparedStatement preparedStatement, boolean hasElement){
+    public EasyShardingStreamResultSet(ResultSet resultSet, Statement statement, boolean hasElement){
 
         this.resultSet = resultSet;
-        this.preparedStatement = preparedStatement;
+        this.statement = statement;
         this.hasElement = hasElement;
         skipFirst=true;
     }
@@ -183,9 +183,11 @@ public final class EasyShardingStreamResultSet implements ShardingStreamResultSe
             log.error("result set close error.",ex);
         }
         try {
-            preparedStatement.close();
+            if(statement!=null){
+                statement.close();
+            }
         }catch (SQLException ex){
-            log.error("prepared statement close error.",ex);
+            log.error("statement close error.",ex);
         }
     }
 }

--- a/sql-core/src/main/java/com/easy/query/core/basic/jdbc/executor/internal/merge/result/impl/EasyStreamResultSet.java
+++ b/sql-core/src/main/java/com/easy/query/core/basic/jdbc/executor/internal/merge/result/impl/EasyStreamResultSet.java
@@ -8,11 +8,11 @@ import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 
@@ -25,13 +25,13 @@ import java.sql.Timestamp;
 public final class EasyStreamResultSet implements StreamResultSet {
     private static final Log log= LogFactory.getLog(EasyStreamResultSet.class);
     private final ResultSet resultSet;
-    private final PreparedStatement preparedStatement;
+    private final Statement statement;
     private boolean closed=false;
 
-    public EasyStreamResultSet(ResultSet resultSet, PreparedStatement preparedStatement) {
+    public EasyStreamResultSet(ResultSet resultSet, Statement statement) {
 
         this.resultSet = resultSet;
-        this.preparedStatement = preparedStatement;
+        this.statement = statement;
     }
 
     @Override
@@ -167,11 +167,11 @@ public final class EasyStreamResultSet implements StreamResultSet {
             log.error("result set close error.",ex);
         }
         try {
-            if(preparedStatement!=null){
-                preparedStatement.close();
+            if(statement!=null){
+                statement.close();
             }
         }catch (SQLException ex){
-            log.error("prepared statement close error.",ex);
+            log.error("statement close error.",ex);
         }
     }
 }

--- a/sql-core/src/main/java/com/easy/query/core/metadata/ColumnMetadata.java
+++ b/sql-core/src/main/java/com/easy/query/core/metadata/ColumnMetadata.java
@@ -131,6 +131,7 @@ public class ColumnMetadata {
     private final List<ColumnMetadata> valueObjectColumnMetadataList;
     private final Supplier<Object> beanConstructorCreator;
     private final JDBCType jdbcType;
+    private final boolean tag;
 
     public ColumnMetadata(ColumnOption columnOption) {
         this.entityMetadata = columnOption.getEntityMetadata();
@@ -146,6 +147,7 @@ public class ColumnMetadata {
         this.propertyName = columnOption.getFullPropertyName();
         this.fieldName = columnOption.getFieldName();
         this.primary = columnOption.isPrimary();
+        this.tag = columnOption.isTag();
         this.generatedKey = columnOption.isGeneratedKey();
         this.version = columnOption.isVersion();
         this.insertIgnore = columnOption.isInsertIgnore();
@@ -316,6 +318,10 @@ public class ColumnMetadata {
 
     public JDBCType getJdbcType() {
         return jdbcType;
+    }
+
+    public boolean isTag() {
+        return tag;
     }
 
     //    public boolean isConcurrentUpdateInTrack() {

--- a/sql-core/src/main/java/com/easy/query/core/metadata/ColumnOption.java
+++ b/sql-core/src/main/java/com/easy/query/core/metadata/ColumnOption.java
@@ -63,6 +63,7 @@ public final class ColumnOption {
     private String fullPropertyName;
     private String comment;
     private JDBCType jdbcType;
+    private boolean tag = false;
 //    private boolean concurrentUpdateInTrack = false;
 
 
@@ -296,6 +297,14 @@ public final class ColumnOption {
 
     public void setJdbcType(JDBCType jdbcType) {
         this.jdbcType = jdbcType;
+    }
+
+    public boolean isTag() {
+        return tag;
+    }
+
+    public void setTag(boolean tag) {
+        this.tag = tag;
     }
 
     //    public boolean isNullable() {

--- a/sql-core/src/main/java/com/easy/query/core/metadata/EntityMetadata.java
+++ b/sql-core/src/main/java/com/easy/query/core/metadata/EntityMetadata.java
@@ -667,6 +667,7 @@ public class EntityMetadata {
             columnOption.setSupportQueryLike(encryption.supportQueryLike());
         }
         if (column != null) {
+            columnOption.setTag(column.tag());
             columnOption.setNullable(column.nullable());
             if (easyQueryOption.isSaveComment()) {
                 columnOption.setComment(column.comment());

--- a/sql-core/src/main/java/com/easy/query/core/migration/DefaultMigrationEntityParser.java
+++ b/sql-core/src/main/java/com/easy/query/core/migration/DefaultMigrationEntityParser.java
@@ -188,6 +188,16 @@ public class DefaultMigrationEntityParser implements MigrationEntityParser {
     }
 
     @Override
+    public boolean isTag(EntityMigrationMetadata entityMigrationMetadata, ColumnMetadata columnMetadata) {
+        Field declaredField = entityMigrationMetadata.getFieldByColumnMetadata(columnMetadata);
+        Column annotation = declaredField.getAnnotation(Column.class);
+        if (annotation != null) {
+            return annotation.tag();
+        }
+        return false;
+    }
+
+    @Override
     public @NotNull List<TableIndexResult> getTableIndexes(EntityMigrationMetadata entityMigrationMetadata) {
         EntityMetadata entityMetadata = entityMigrationMetadata.getEntityMetadata();
         return getClassTableIndexes(entityMigrationMetadata,entityMetadata.getEntityClass());

--- a/sql-core/src/main/java/com/easy/query/core/migration/DefaultMigrationsSQLGenerator.java
+++ b/sql-core/src/main/java/com/easy/query/core/migration/DefaultMigrationsSQLGenerator.java
@@ -187,6 +187,8 @@ public class DefaultMigrationsSQLGenerator implements MigrationsSQLGenerator {
             columnMigrationData.setOldColumnName(column.getFieldName());
             String columnOldName = databaseMigrationProvider.getMigrationEntityParser().getColumnOldName(entityMigrationMetadata, column);
             columnMigrationData.setOldColumnName(columnOldName);
+            boolean isTag = databaseMigrationProvider.getMigrationEntityParser().isTag(entityMigrationMetadata, column);
+            columnMigrationData.setTag(isTag);
             columns.add(columnMigrationData);
 
         }

--- a/sql-core/src/main/java/com/easy/query/core/migration/MigrationEntityParser.java
+++ b/sql-core/src/main/java/com/easy/query/core/migration/MigrationEntityParser.java
@@ -61,6 +61,14 @@ public interface MigrationEntityParser {
      */
     String getColumnOldName(EntityMigrationMetadata entityMigrationMetadata, ColumnMetadata columnMetadata);
 
+    /**
+     * 当前列是否是标签仅仅tsdb生效
+     * @param entityMigrationMetadata
+     * @param columnMetadata
+     * @return
+     */
+    boolean isTag(EntityMigrationMetadata entityMigrationMetadata, ColumnMetadata columnMetadata);
+
     @NotNull
     List<TableIndexResult> getTableIndexes(EntityMigrationMetadata entityMigrationMetadata);
     @NotNull

--- a/sql-core/src/main/java/com/easy/query/core/migration/data/ColumnMigrationData.java
+++ b/sql-core/src/main/java/com/easy/query/core/migration/data/ColumnMigrationData.java
@@ -43,6 +43,10 @@ public class ColumnMigrationData {
      * 旧列名
      */
     private String oldColumnName;
+    /**
+     * 是否是标签
+     */
+    private boolean tag;
 
     public String getName() {
         return name;
@@ -106,5 +110,13 @@ public class ColumnMigrationData {
 
     public void setOldColumnName(String oldColumnName) {
         this.oldColumnName = oldColumnName;
+    }
+
+    public boolean isTag() {
+        return tag;
+    }
+
+    public void setTag(boolean tag) {
+        this.tag = tag;
     }
 }

--- a/sql-core/src/main/java/com/easy/query/core/sql/DefaultJdbcSQLExecutor.java
+++ b/sql-core/src/main/java/com/easy/query/core/sql/DefaultJdbcSQLExecutor.java
@@ -49,7 +49,7 @@ public class DefaultJdbcSQLExecutor implements JdbcSQLExecutor{
         EasyJdbcExecutorUtil.logSQL(printSql, sql, easyConnection, shardingPrint, replicaPrint);
         boolean listen = jdbcExecutorListener.enable() && executorContext.getExpressionContext().getBehavior().hasBehavior(EasyBehaviorEnum.JDBC_LISTEN);
         SQLConsumer<Statement> configurer = executorContext.getConfigurer(shardingPrint);
-        PreparedStatement ps = null;
+        Statement ps = null;
         ResultSet rs = null;
         List<SQLParameter> parameters = EasyJdbcExecutorUtil.extractParameters(null, sqlParameters, printSql, sqlParameterPrintFormat, easyConnection, shardingPrint, replicaPrint);
 
@@ -63,13 +63,21 @@ public class DefaultJdbcSQLExecutor implements JdbcSQLExecutor{
                 jdbcListenBeforeArg = new JdbcExecuteBeforeArg(traceId, sql, Collections.singletonList(parameters), executorContext.getExecuteMethod());
                 jdbcExecutorListener.onExecuteBefore(jdbcListenBeforeArg);
             }
-            ps = EasyJdbcExecutorUtil.createPreparedStatement(easyConnection.getConnection(), sql, parameters, easyJdbcTypeHandler);
-
             long start = printSql ? System.currentTimeMillis() : 0L;
-            if (configurer != null) {
-                configurer.accept(ps);
+            if (EasyCollectionUtil.isEmpty(parameters)) {
+                Statement s = easyConnection.getConnection().createStatement();
+                ps = s;
+                if (configurer != null) {
+                    configurer.accept(s);
+                }
+                rs = s.executeQuery(sql);
+            } else {
+                ps = EasyJdbcExecutorUtil.createPreparedStatement(easyConnection.getConnection(), sql, parameters, easyJdbcTypeHandler);
+                if (configurer != null) {
+                    configurer.accept(ps);
+                }
+                rs = ((PreparedStatement) ps).executeQuery();
             }
-            rs = ps.executeQuery();
             long end = printSql ? System.currentTimeMillis() : 0L;
             if (printSql) {
                 EasyJdbcExecutorUtil.logUse(true, start, end, easyConnection, shardingPrint, replicaPrint);
@@ -246,7 +254,7 @@ public class DefaultJdbcSQLExecutor implements JdbcSQLExecutor{
         JdbcExecutorListener jdbcExecutorListener = runtimeContext.getJdbcExecutorListener();
         boolean listen = jdbcExecutorListener.enable() && executorContext.getExpressionContext().getBehavior().hasBehavior(EasyBehaviorEnum.JDBC_LISTEN);
         JdbcExecuteBeforeArg jdbcListenBeforeArg = null;
-        PreparedStatement ps = null;
+        Statement ps = null;
         Exception exception = null;
         int r = 0;
         try {
@@ -256,8 +264,14 @@ public class DefaultJdbcSQLExecutor implements JdbcSQLExecutor{
                 jdbcListenBeforeArg = new JdbcExecuteBeforeArg(traceId, sql, Collections.singletonList(parameters), executorContext.getExecuteMethod());
                 jdbcExecutorListener.onExecuteBefore(jdbcListenBeforeArg);
             }
-            ps = EasyJdbcExecutorUtil.createPreparedStatement(easyConnection.getConnection(), sql, parameters, easyJdbcTypeHandlerManager);
-            r = ps.executeUpdate();
+            if (EasyCollectionUtil.isEmpty(parameters)) {
+                Statement s = easyConnection.getConnection().createStatement();
+                ps = s;
+                r = s.executeUpdate(sql);
+            } else {
+                ps = EasyJdbcExecutorUtil.createPreparedStatement(easyConnection.getConnection(), sql, parameters, easyJdbcTypeHandlerManager);
+                r = ((PreparedStatement) ps).executeUpdate();
+            }
             EasyJdbcExecutorUtil.logResult(printSql, r, easyConnection, shardingPrint, replicaPrint);
         } catch (Exception e) {
             exception = e;

--- a/sql-core/src/main/java/com/easy/query/core/util/EasyDatabaseUtil.java
+++ b/sql-core/src/main/java/com/easy/query/core/util/EasyDatabaseUtil.java
@@ -49,14 +49,21 @@ public class EasyDatabaseUtil {
     public static String getDatabaseName(DataSource dataSource, Supplier<String> def) {
         try (Connection connection = dataSource.getConnection()) {
             // 方法 1: 使用 getCatalog()
-            return connection.getCatalog();
-//            String databaseName = connection.getCatalog();
-//            if (databaseName != null) {
-//                return databaseName;
-//            }
-        } catch (Exception e) {
-//            e.printStackTrace();
+            String databaseName = connection.getCatalog();
+            if (databaseName != null) {
+                return databaseName;
+            }
+        } catch (Exception ignored) {
         }
+        // 方法 2: 如果 getCatalog() 失败，尝试从 JDBC URL 解析（通过反射获取 credentials）
+        try {
+            Credentials credentials = getCredentialsByReflection(dataSource);
+            if (EasyStringUtil.isNotBlank(credentials.databaseName)) {
+                return credentials.databaseName;
+            }
+        } catch (Exception ignored) {
+        }
+
         if (def == null) {
             return null;
         }

--- a/sql-core/src/main/java/com/easy/query/core/util/EasyJdbcExecutorUtil.java
+++ b/sql-core/src/main/java/com/easy/query/core/util/EasyJdbcExecutorUtil.java
@@ -31,6 +31,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -181,13 +182,17 @@ public class EasyJdbcExecutorUtil {
         return EasyOptionUtil.isPrintSQL(executorContext.getExpressionContext());
     }
 
-    public static void clear(PreparedStatement ps) {
+    public static void clear(Statement ps) {
         try {
             if (ps != null) {
                 ps.close();
             }
         } catch (SQLException ignored) {
         }
+    }
+
+    public static void clear(PreparedStatement ps) {
+        clear((Statement) ps);
     }
 
     public static PreparedStatement createPreparedStatement(Connection connection, String sql, List<SQLParameter> sqlParameters, JdbcTypeHandlerManager easyJdbcTypeHandlerManager) throws SQLException {

--- a/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/config/TSDBDatabaseConfiguration.java
+++ b/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/config/TSDBDatabaseConfiguration.java
@@ -12,7 +12,6 @@ import com.easy.query.tsdb.func.TSDBFuncImpl;
 import com.easy.query.tsdb.migration.TSDBDatabaseMigrationProvider;
 import com.easy.query.tsdb.migration.TSDBMigrationEntityParser;
 
-import java.util.UUID;
 
 /**
  * create time 2023/5/10 13:40

--- a/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/expression/TSDBInsertSQLExpression.java
+++ b/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/expression/TSDBInsertSQLExpression.java
@@ -15,7 +15,10 @@ import com.easy.query.core.expression.sql.expression.impl.InsertSQLExpressionImp
 import com.easy.query.core.metadata.EntityMetadata;
 import com.easy.query.core.util.EasyClassUtil;
 import com.easy.query.core.util.EasySQLExpressionUtil;
+import com.easy.query.core.util.EasyStringUtil;
+import com.easy.query.core.metadata.ColumnMetadata;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -37,25 +40,47 @@ public class TSDBInsertSQLExpression extends InsertSQLExpressionImpl {
         EasySQLExpressionUtil.expressionInvokeRoot(toSQLContext);
         EntityTableSQLExpression easyTableSQLExpression = tables.get(0);
         String tableName = easyTableSQLExpression.toSQL(toSQLContext);
-//        List<SQLSegment> sqlSegments = columns.getSQLSegments();
+        EntityMetadata entityMetadata = easyTableSQLExpression.getEntityMetadata();
+        List<SQLSegment> sqlSegments = columns.getSQLSegments();
+        List<SQLSegment> tagSegments = new ArrayList<>();
+        List<SQLSegment> fieldSegments = new ArrayList<>();
+
+        for (SQLSegment sqlSegment : sqlSegments) {
+            if (sqlSegment instanceof SQLEntitySegment) {
+                SQLEntitySegment sqlEntitySegment = (SQLEntitySegment) sqlSegment;
+                ColumnMetadata columnMetadata = entityMetadata.getColumnOrNull(sqlEntitySegment.getPropertyName());
+                if (columnMetadata.isTag()) {
+                    tagSegments.add(sqlSegment);
+                } else {
+                    fieldSegments.add(sqlSegment);
+                }
+            } else {
+                fieldSegments.add(sqlSegment);
+            }
+        }
+
         ExpressionContext expressionContext = entitySQLExpressionMetadata.getExpressionContext();
         boolean hasIgnore = expressionContext.getBehavior().hasBehavior(EasyBehaviorEnum.ON_DUPLICATE_KEY_IGNORE);
         StringBuilder sql = new StringBuilder(hasIgnore ? "INSERT IGNORE INTO " : "INSERT INTO ");
-        sql.append(tableName).append(" (");
+        sql.append(tableName);
 
-        Iterator<SQLSegment> iterator = columns.getSQLSegments().iterator();
-        SQLSegment firstColumn = iterator.next();
-
-        sql.append(getColumnNameWithOwner(firstColumn,toSQLContext));
-        while(iterator.hasNext()){
-            SQLSegment next = iterator.next();
-            sql.append(",").append(getColumnNameWithOwner(next,toSQLContext));
+        if (!tagSegments.isEmpty()) {
+            String superTableName = entityMetadata.getTableName();
+            if (EasyStringUtil.isNotBlank(superTableName)) {
+                sql.append(" USING ").append(superTableName).append(" TAGS (");
+                renderValues(tagSegments, sql, toSQLContext);
+                sql.append(")");
+            }
         }
 
-        sql.append(") VALUES (").append(columns.toSQL(toSQLContext)).append(")");
+        sql.append(" (");
+        renderSegments(fieldSegments, sql, toSQLContext);
+        sql.append(") VALUES (");
+        renderValues(fieldSegments, sql, toSQLContext);
+        sql.append(")");
+
         if (!hasIgnore && expressionContext.getBehavior().hasBehavior(EasyBehaviorEnum.ON_DUPLICATE_KEY_UPDATE)) {
             QueryRuntimeContext runtimeContext = getRuntimeContext();
-            EntityMetadata entityMetadata = easyTableSQLExpression.getEntityMetadata();
             TableAvailable entityTable = easyTableSQLExpression.getEntityTable();
             Collection<String> keyProperties = entityMetadata.getKeyProperties();
             StringBuilder duplicateKeyUpdateSql = new StringBuilder();
@@ -64,25 +89,43 @@ public class TSDBInsertSQLExpression extends InsertSQLExpressionImpl {
             Set<String> duplicateKeyUpdateColumnsSet = getColumnsSet(columns);
             for (SQLSegment sqlSegment : realDuplicateKeyUpdateColumnsSQLSegments) {
                 if (!(sqlSegment instanceof SQLEntitySegment)) {
-                    throw new EasyQueryInvalidOperationException("insert not support:" + EasyBehaviorEnum.ON_DUPLICATE_KEY_UPDATE.name()+",column type:"+ EasyClassUtil.getSimpleName(sqlSegment.getClass()));
+                    throw new EasyQueryInvalidOperationException("insert not support:" + EasyBehaviorEnum.ON_DUPLICATE_KEY_UPDATE.name() + ",column type:" + EasyClassUtil.getSimpleName(sqlSegment.getClass()));
                 }
                 SQLEntitySegment sqlEntitySegment = (SQLEntitySegment) sqlSegment;
                 String propertyName = sqlEntitySegment.getPropertyName();
-                if(keyProperties.contains(propertyName)||!duplicateKeyUpdateColumnsSet.contains(propertyName)){
+                if (keyProperties.contains(propertyName) || !duplicateKeyUpdateColumnsSet.contains(propertyName)) {
                     continue;
                 }
-                if(duplicateKeyUpdateSql.length()!=0){
+                if (duplicateKeyUpdateSql.length() != 0) {
                     duplicateKeyUpdateSql.append(", ");
                 }
                 String columnName = entityTable.getColumnName(propertyName);
                 String quoteName = EasySQLExpressionUtil.getQuoteName(runtimeContext, columnName);
                 duplicateKeyUpdateSql.append(quoteName).append(" = ").append("VALUES(").append(quoteName).append(")");
             }
-            if(duplicateKeyUpdateSql.length()>0){
+            if (duplicateKeyUpdateSql.length() > 0) {
                 sql.append(" ON DUPLICATE KEY UPDATE ");
                 sql.append(duplicateKeyUpdateSql);
             }
         }
         return sql.toString();
+    }
+
+    private void renderSegments(List<SQLSegment> segments, StringBuilder sql, ToSQLContext toSQLContext) {
+        for (int i = 0; i < segments.size(); i++) {
+            if (i > 0) {
+                sql.append(",");
+            }
+            sql.append(getColumnNameWithOwner(segments.get(i), toSQLContext));
+        }
+    }
+
+    private void renderValues(List<SQLSegment> segments, StringBuilder sql, ToSQLContext toSQLContext) {
+        for (int i = 0; i < segments.size(); i++) {
+            if (i > 0) {
+                sql.append(",");
+            }
+            sql.append(segments.get(i).toSQL(toSQLContext));
+        }
     }
 }

--- a/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBDatabaseMigrationProvider.java
+++ b/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBDatabaseMigrationProvider.java
@@ -102,4 +102,32 @@ public class TSDBDatabaseMigrationProvider extends DefaultDatabaseMigrationProvi
             throw new com.easy.query.core.exception.EasyQuerySQLCommandException(e);
         }
     }
+
+    @Override
+    protected MigrationCommand renameColumn(TableMigrationData tableMigrationData, String oldColumnName, ColumnMigrationData columnMigrationData) {
+        String sql = "ALTER TABLE " + getQuoteSQLName(tableMigrationData.getSchema(), tableMigrationData.getTableName()) +
+                " RENAME COLUMN " + getQuoteSQLName(oldColumnName) + " TO " + getQuoteSQLName(columnMigrationData.getName()) + ";";
+        return new DefaultMigrationCommand(sql);
+    }
+
+    @Override
+    protected MigrationCommand addColumn(TableMigrationData tableMigrationData, ColumnMigrationData columnMigrationData) {
+        StringBuilder sql = new StringBuilder();
+        sql.append("ALTER TABLE ").append(getQuoteSQLName(tableMigrationData.getSchema(), tableMigrationData.getTableName()))
+                .append(" ADD COLUMN ").append(getQuoteSQLName(columnMigrationData.getName())).append(" ");
+        ColumnDbTypeResult columnDbTypeResult = new ColumnDbTypeResult(columnMigrationData.getDbType(), columnMigrationData.getDefValue());
+        sql.append(columnDbTypeResult.columnType);
+        sql.append(";");
+        return new DefaultMigrationCommand(sql.toString());
+    }
+
+    @Override
+    protected MigrationCommand createIndex(TableMigrationData table, com.easy.query.core.migration.data.IndexMigrationData tableIndex) {
+        return null; // TDengine 不支持传统索引
+    }
+
+    @Override
+    protected MigrationCommand createTableForeignKey(TableMigrationData tableMigrationData, com.easy.query.core.migration.data.ForeignKeyMigrationData foreignKeyMigrationData) {
+        return null; // TDengine 不支持外键
+    }
 }

--- a/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBDatabaseMigrationProvider.java
+++ b/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBDatabaseMigrationProvider.java
@@ -3,8 +3,21 @@ package com.easy.query.tsdb.migration;
 import com.easy.query.core.configuration.dialect.SQLKeyword;
 import com.easy.query.core.migration.DefaultDatabaseMigrationProvider;
 import com.easy.query.core.migration.MigrationEntityParser;
-
+import com.easy.query.core.migration.data.ColumnMigrationData;
+import com.easy.query.core.migration.data.TableMigrationData;
+import com.easy.query.core.migration.commands.DefaultMigrationCommand;
+import com.easy.query.core.migration.MigrationCommand;
+import com.easy.query.core.migration.ColumnDbTypeResult;
+import com.easy.query.core.util.EasyCollectionUtil;
+import com.easy.query.core.util.EasyDatabaseUtil;
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * create time 2025/1/18 22:23
@@ -15,5 +28,78 @@ import javax.sql.DataSource;
 public class TSDBDatabaseMigrationProvider extends DefaultDatabaseMigrationProvider {
     public TSDBDatabaseMigrationProvider(DataSource dataSource, SQLKeyword sqlKeyword, MigrationEntityParser migrationEntityParser) {
         super(dataSource, sqlKeyword,migrationEntityParser);
+    }
+
+    @Override
+    public String databaseExistSQL(String databaseName) {
+        return "SHOW DATABASES LIKE '" + databaseName + "'";
+    }
+
+    @Override
+    public String createDatabaseSQL(String databaseName) {
+        return "CREATE DATABASE IF NOT EXISTS " + getQuoteSQLName(databaseName);
+    }
+
+    @Override
+    public MigrationCommand createTable(TableMigrationData tableMigrationData) {
+        List<ColumnMigrationData> tags = EasyCollectionUtil.filter(tableMigrationData.getColumns(), ColumnMigrationData::isTag);
+        List<ColumnMigrationData> columns = EasyCollectionUtil.filter(tableMigrationData.getColumns(), s -> !s.isTag());
+
+        StringBuilder sql = new StringBuilder();
+        if (EasyCollectionUtil.isNotEmpty(tags)) {
+            sql.append("CREATE STABLE IF NOT EXISTS ");
+        } else {
+            sql.append("CREATE TABLE IF NOT EXISTS ");
+        }
+        sql.append(getQuoteSQLName(tableMigrationData.getSchema(), tableMigrationData.getTableName())).append(" ( ");
+        
+        for (int i = 0; i < columns.size(); i++) {
+            ColumnMigrationData column = columns.get(i);
+            sql.append(newLine)
+                    .append(getQuoteSQLName(column.getName()))
+                    .append(" ");
+            
+            ColumnDbTypeResult columnDbTypeResult = new ColumnDbTypeResult(column.getDbType(), column.getDefValue());
+            String columnType = columnDbTypeResult.columnType;
+            // TDengine 3.0 首列必须是 TIMESTAMP
+            if (i == 0 && columnType.toUpperCase().startsWith("DATETIME")) {
+                sql.append("TIMESTAMP");
+            } else {
+                sql.append(columnType);
+            }
+            // TDengine 语法不支持显式的 NULL/NOT NULL 声明
+            sql.append(",");
+        }
+        sql.deleteCharAt(sql.length() - 1);
+        sql.append(newLine).append(" )");
+
+        if (EasyCollectionUtil.isNotEmpty(tags)) {
+            sql.append(" TAGS ( ");
+            for (ColumnMigrationData tag : tags) {
+                sql.append(newLine)
+                        .append(getQuoteSQLName(tag.getName()))
+                        .append(" ");
+                ColumnDbTypeResult columnDbTypeResult = new ColumnDbTypeResult(tag.getDbType(), tag.getDefValue());
+                sql.append(columnDbTypeResult.columnType);
+                // 标签列同样不需要 NULL 声明
+                sql.append(",");
+            }
+            sql.deleteCharAt(sql.length() - 1);
+            sql.append(newLine).append(" )");
+        }
+        sql.append(";");
+        return new DefaultMigrationCommand(sql.toString());
+    }
+
+    @Override
+    public boolean tableExists(String schema, String tableName) {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet rs = metaData.getTables(schema, null, tableName, null)) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new com.easy.query.core.exception.EasyQuerySQLCommandException(e);
+        }
     }
 }

--- a/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBMigrationEntityParser.java
+++ b/sql-db-support/sql-tsdb/src/main/java/com/easy/query/tsdb/migration/TSDBMigrationEntityParser.java
@@ -1,6 +1,14 @@
 package com.easy.query.tsdb.migration;
 
+import com.easy.query.core.migration.ColumnDbTypeResult;
 import com.easy.query.core.migration.DefaultMigrationEntityParser;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * create time 2025/1/18 20:07
@@ -9,4 +17,45 @@ import com.easy.query.core.migration.DefaultMigrationEntityParser;
  * @author xuejiaming
  */
 public class TSDBMigrationEntityParser extends DefaultMigrationEntityParser {
+    private static final Map<Class<?>, ColumnDbTypeResult> columnTypeMap = new HashMap<>();
+
+    static {
+        columnTypeMap.put(boolean.class, new ColumnDbTypeResult("BOOL", "0"));
+        columnTypeMap.put(Boolean.class, new ColumnDbTypeResult("BOOL", null));
+        columnTypeMap.put(float.class, new ColumnDbTypeResult("FLOAT", "0"));
+        columnTypeMap.put(Float.class, new ColumnDbTypeResult("FLOAT", null));
+        columnTypeMap.put(double.class, new ColumnDbTypeResult("DOUBLE", "0"));
+        columnTypeMap.put(Double.class, new ColumnDbTypeResult("DOUBLE", null));
+        columnTypeMap.put(short.class, new ColumnDbTypeResult("SMALLINT", "0"));
+        columnTypeMap.put(Short.class, new ColumnDbTypeResult("SMALLINT", null));
+        columnTypeMap.put(int.class, new ColumnDbTypeResult("INT", "0"));
+        columnTypeMap.put(Integer.class, new ColumnDbTypeResult("INT", null));
+        columnTypeMap.put(long.class, new ColumnDbTypeResult("BIGINT", "0"));
+        columnTypeMap.put(Long.class, new ColumnDbTypeResult("BIGINT", null));
+        columnTypeMap.put(byte.class, new ColumnDbTypeResult("TINYINT", "0"));
+        columnTypeMap.put(Byte.class, new ColumnDbTypeResult("TINYINT", null));
+        columnTypeMap.put(BigDecimal.class, new ColumnDbTypeResult("DECIMAL(16,2)", null));
+        columnTypeMap.put(LocalDateTime.class, new ColumnDbTypeResult("TIMESTAMP", null));
+        columnTypeMap.put(LocalDate.class, new ColumnDbTypeResult("DATE", null));
+        columnTypeMap.put(LocalTime.class, new ColumnDbTypeResult("TIME", null));
+        columnTypeMap.put(String.class, new ColumnDbTypeResult("VARCHAR(255)", null));
+        columnTypeMap.put(UUID.class, new ColumnDbTypeResult("VARCHAR(36)", null));
+    }
+
+    @Override
+    protected Map<Class<?>, ColumnDbTypeResult> getColumnTypeMap() {
+        return columnTypeMap;
+    }
+
+    @Override
+    protected String replaceSqlTypeLength(String sqlType, int length, int scale) {
+        if (sqlType == null || sqlType.isEmpty()) {
+            return sqlType;
+        }
+        String upperType = sqlType.toUpperCase();
+        if (upperType.startsWith("INT") || upperType.startsWith("TINYINT") || upperType.startsWith("SMALLINT") || upperType.startsWith("BIGINT") || upperType.startsWith("BOOL") || upperType.startsWith("TIMESTAMP") || upperType.startsWith("FLOAT") || upperType.startsWith("DOUBLE") || upperType.startsWith("DATE") || upperType.startsWith("TIME")) {
+            return sqlType;
+        }
+        return super.replaceSqlTypeLength(sqlType, length, scale);
+    }
 }


### PR DESCRIPTION
针对 TDengine 的数据模型（STable/TAGS）及 DDL 语法限制（3.0+）进行了全面的适配和优化：

### 1. 核心功能支持 (STable & TAGS)
- **超级表 (STable) 支持**：引入了对 TDengine 超级表的支持，允许通过实体类定义其时序特性。
- **标签 (TAGS) 支持**：支持在实体中定义标签列，并能在建表时正确生成 `TAGS` 子句。

### 2. 字段类型与长度优化 (针对 3.0+ 语法)
- **移除内置类型长度限制**：重载了 `TSDBMigrationEntityParser`。针对 `INT`, `BIGINT`, `SMALLINT`, `TINYINT`, `FLOAT`, `DOUBLE`, `BOOL`, `TIMESTAMP` 等内置类型，去除了 DDL 中的显示宽度/长度参数（如不再输出 `INT(11)`）。
  - **原因**：TDengine 3.0 对这些固定长度类型不允许指定长度，否则会导致语法错误。
- **布尔类型适配**：将 `boolean` 准确映射为 TDengine 的 `BOOL` 类型，而非 MySQL 风格的 `TINYINT(1)`。
- **全局拦截**：在 `replaceSqlTypeLength` 中增加了拦截逻辑，确保即使在实体上配置了 `length` 属性，对于上述固定长度类型也会自动过滤。

### 3. DDL 迁移语法修正 (`TSDBDatabaseMigrationProvider`)
- **空值约束清理**：从 DDL 语句中移除了 `NULL` / `NOT NULL` 声明。
  - **原因**：TDengine 语法不支持在此处声明空值约束。
- **ALTER TABLE 语句重写**：
  - `addColumn`：采用了符合 TDengine 规范的 `ADD COLUMN` 语法。
  - `renameColumn`：适配了 TDengine 3.x 的 `RENAME COLUMN` 语法，替代了不兼容的 `CHANGE` 语法。
- **屏蔽不支持特性**：显式屏蔽了索引（Index）和外键（ForeignKey）的生成过程，以符合时序数据库的实际存储模型。

### 4. 代码修正与清理
- 修正了 `TSDBDatabaseConfiguration` 中的服务注册引用逻辑，清理了冗余引用（如 UUID），优化了代码质量。

---
本 PR 提供的改动已在本地通过了 TDengine 3.x 环境的实测，能够确保表结构自动迁移的准确性和稳定性。