### PR TITLE
fix: 修复 H2 建表时表级注释生成 MySQL 内联语法导致建表失败

### DIFF
--- a/sql-db-support/sql-h2/src/main/java/com/easy/query/h2/migration/H2DatabaseMigrationProvider.java
+++ b/sql-db-support/sql-h2/src/main/java/com/easy/query/h2/migration/H2DatabaseMigrationProvider.java
@@ -118,11 +118,15 @@ public class H2DatabaseMigrationProvider extends AbstractDatabaseMigrationProvid
         }else{
             sql.deleteCharAt(sql.length() - 1);
         }
+        sql.append(newLine).append(");");
+        // H2 不支持 MySQL 内联的表级 COMMENT='...' 语法，需使用独立的 COMMENT ON TABLE 语句
         String tableComment = getTableComment(tableMigrationData, "'");
         if (EasyStringUtil.isNotBlank(tableComment)) {
-            sql.append(" COMMENT=").append(tableComment);
+            sql.append(newLine)
+                    .append("COMMENT ON TABLE ")
+                    .append(getQuoteSQLName(tableMigrationData.getSchema(), tableMigrationData.getTableName()))
+                    .append(" IS ").append(tableComment).append(";");
         }
-        sql.append(newLine).append(");");
         return new DefaultMigrationCommand(sql.toString());
     }
 

--- a/sql-test/src/main/java/com/easy/query/test/h2/H2QueryTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/h2/H2QueryTest.java
@@ -11,6 +11,7 @@ import com.easy.query.test.entity.SysUser;
 import com.easy.query.test.entity.Topic;
 import com.easy.query.test.h2.domain.ALLTYPE;
 import com.easy.query.test.h2.domain.ALLTYPE1;
+import com.easy.query.test.h2.domain.H2TableCommentEntity;
 import com.easy.query.test.h2.domain.ALLTYPESharding;
 import com.easy.query.test.h2.domain.DefTable;
 import com.easy.query.test.h2.domain.DefTableLeft1;
@@ -782,6 +783,30 @@ public class H2QueryTest extends H2BaseTest {
                     "id2 VARCHAR(255) NOT NULL , \n" +
                     " PRIMARY KEY (id1, id2)\n" +
                     ");",s.getSQL());
+            s.commit();
+        });
+    }
+
+    @Test
+    public void testTableCommentDDL() {
+        DatabaseCodeFirst databaseCodeFirst = easyEntityQuery.getDatabaseCodeFirst();
+        CodeFirstCommand dropCommand = databaseCodeFirst.dropTableIfExistsCommand(Arrays.asList(H2TableCommentEntity.class));
+        dropCommand.executeWithTransaction(s -> s.commit());
+        CodeFirstCommand syncCommand = databaseCodeFirst.syncTableCommand(Arrays.asList(H2TableCommentEntity.class));
+        // 执行建表语句验证 H2 能够正确解析；修复前 MySQL 风格的内联 COMMENT='...' 放在括号内会导致语法错误
+        syncCommand.executeWithTransaction(s -> {
+            // 统一换行符，兼容不同平台的 System.lineSeparator()
+            String ddl = s.getSQL().replace("\r\n", "\n");
+            // 列级注释保持内联 COMMENT，表级注释生成为独立的 COMMENT ON TABLE 语句
+            Assert.assertEquals("\n" +
+                    "CREATE TABLE IF NOT EXISTS t_h2_table_comment ( \n" +
+                    "id VARCHAR(255) NOT NULL  COMMENT '主键ID',\n" +
+                    "name VARCHAR(255) NULL  COMMENT '名称', \n" +
+                    " PRIMARY KEY (id)\n" +
+                    ");\n" +
+                    "COMMENT ON TABLE t_h2_table_comment IS 'H2表注释测试';", ddl);
+            // 不得出现 MySQL 内联表级注释语法
+            Assert.assertFalse(ddl.contains("COMMENT="));
             s.commit();
         });
     }

--- a/sql-test/src/main/java/com/easy/query/test/h2/domain/H2TableCommentEntity.java
+++ b/sql-test/src/main/java/com/easy/query/test/h2/domain/H2TableCommentEntity.java
@@ -1,0 +1,24 @@
+package com.easy.query.test.h2.domain;
+
+import com.easy.query.core.annotation.Column;
+import com.easy.query.core.annotation.EntityProxy;
+import com.easy.query.core.annotation.Table;
+import com.easy.query.core.proxy.ProxyEntityAvailable;
+import com.easy.query.test.h2.domain.proxy.H2TableCommentEntityProxy;
+import lombok.Data;
+
+/**
+ * create time 2026/6/14
+ * H2 表注释回归测试实体，用于验证表级注释生成为独立的 COMMENT ON TABLE 语句
+ */
+@Data
+@Table(value = "t_h2_table_comment", comment = "H2表注释测试")
+@EntityProxy
+public class H2TableCommentEntity implements ProxyEntityAvailable<H2TableCommentEntity, H2TableCommentEntityProxy> {
+
+    @Column(primaryKey = true, comment = "主键ID")
+    private String id;
+
+    @Column(comment = "名称")
+    private String name;
+}


### PR DESCRIPTION
在使用 Easy-Query 的 H2 数据库迁移功能时，如果实体类通过 `@Table(comment = "...")` 定义了表级注释，当前代码会生成类似 MySQL 的内联注释语法：

```sql
CREATE TABLE ... ( ... ) COMMENT='表注释';
```

但 H2 数据库并不支持这种语法（仅在 MySQL 模式下有限支持），导致 H2 执行建表 SQL 时报错，建表失败。