### PR TITLE
fix(core): skip non-autoSelect columns in partition-by select of include with limit

### DIFF
--- a/sql-core/src/main/java/com/easy/query/core/util/EasyNavigateUtil.java
+++ b/sql-core/src/main/java/com/easy/query/core/util/EasyNavigateUtil.java
@@ -175,6 +175,9 @@ public class EasyNavigateUtil {
                 }).where(m -> m.ge("__row__", offset + 1).le("__row__", offset + rows))
                 .select(endNavigateParams.getEntityNavigateMetadata().getNavigatePropertyType(), o -> {
                     for (Map.Entry<String, ColumnMetadata> columnMetadataEntry : entityMetadata.getProperty2ColumnMap().entrySet()) {
+                        if (!columnMetadataEntry.getValue().isAutoSelect()) {
+                            continue;
+                        }
 //                            o.column(columnMetadataEntry.getValue().getName());
                         o.sqlNativeSegment("{0}", c -> {
                             c.expression(columnMetadataEntry.getValue().getName());

--- a/sql-test/src/main/java/com/easy/query/test/mysql8/BaseTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/mysql8/BaseTest.java
@@ -34,6 +34,8 @@ import com.easy.query.test.mysql8.entity.M8AutoA;
 import com.easy.query.test.mysql8.entity.M8AutoB;
 import com.easy.query.test.mysql8.entity.M8Child;
 import com.easy.query.test.mysql8.entity.M8Comment;
+import com.easy.query.test.mysql8.entity.M8IncludeLimitChild;
+import com.easy.query.test.mysql8.entity.M8IncludeLimitTopic;
 import com.easy.query.test.mysql8.entity.M8Parent;
 import com.easy.query.test.mysql8.entity.M8ParentChild;
 import com.easy.query.test.mysql8.entity.M8Role3;
@@ -183,13 +185,13 @@ public class BaseTest {
         databaseCodeFirst.createDatabaseIfNotExists();
 //        CodeFirstCommand codeFirstCommand = databaseCodeFirst.syncTableCommand(Arrays.asList(SysUser.class,SysBank.class, SysBankCard.class,  SysUserBook.class, M8Comment.class));
 //        codeFirstCommand.executeWithTransaction(s -> s.commit());
-        CodeFirstCommand codeFirstCommand2 = databaseCodeFirst.dropTableIfExistsCommand(Arrays.asList(TableNoKey.class,SysUser.class, SysBankCard.class, SysBank.class, SysUserBook.class, M8Comment.class, M8Parent.class, M8Child.class, M8ParentChild.class,
+        CodeFirstCommand codeFirstCommand2 = databaseCodeFirst.dropTableIfExistsCommand(Arrays.asList(TableNoKey.class,SysUser.class, SysBankCard.class, SysBank.class, SysUserBook.class, M8Comment.class, M8Parent.class, M8Child.class, M8ParentChild.class, M8IncludeLimitTopic.class, M8IncludeLimitChild.class,
                 M8Province.class, M8City.class, M8Area.class, M8AreaBuild.class, TreeA.class, TreeB.class, BatchInsert.class, Comment.class, M8SaveRoot.class, M8SaveRoot2Many.class, M8SaveRootMany.class, M8SaveRootMiddleMany.class, M8SaveRootOne.class,M8SaveRootOne2.class, M8SaveRootManyOne.class,
                 M8SaveA.class, M8SaveB.class, M8SaveC.class, M8SaveD.class, M8User3.class, M8UserRole3.class, M8Role3.class, M8ToMany1.class, M8ToMany2.class, M8ToMany3.class, M8AutoA.class, M8AutoB.class, OffsetChunkTest.class, MyConfigLogicDelete.class, M8UserTest.class,
                 MyTask.class, MySubTask1.class, MySubTask2.class, MyTask1Ext.class, MyTask2Ext.class));
         codeFirstCommand2.executeWithTransaction(s -> s.commit());
 
-        CodeFirstCommand codeFirstCommand1 = databaseCodeFirst.syncTableCommand(Arrays.asList(TableNoKey.class,SysUser.class, SysBank.class, SysBankCard.class, SysUserBook.class, M8Comment.class, M8Parent.class, M8Child.class, M8ParentChild.class,
+        CodeFirstCommand codeFirstCommand1 = databaseCodeFirst.syncTableCommand(Arrays.asList(TableNoKey.class,SysUser.class, SysBank.class, SysBankCard.class, SysUserBook.class, M8Comment.class, M8Parent.class, M8Child.class, M8ParentChild.class, M8IncludeLimitTopic.class, M8IncludeLimitChild.class,
                 M8Province.class, M8City.class, M8Area.class, M8AreaBuild.class,M8AreaBuildLicense.class, TreeA.class, TreeB.class, BatchInsert.class,Comment.class, M8SaveRoot.class, M8SaveRoot2Many.class, M8SaveRootMany.class, M8SaveRootMiddleMany.class, M8SaveRootOne.class,M8SaveRootOne2.class,M8SaveRootManyOne.class,
                 M8SaveA.class, M8SaveB.class, M8SaveC.class, M8SaveD.class, M8User3.class, M8UserRole3.class, M8Role3.class, M8ToMany1.class, M8ToMany2.class, M8ToMany3.class,M8AutoA.class,M8AutoB.class,OffsetChunkTest.class, SysDept.class, MyConfigLogicDelete.class,M8UserTest.class,
                 MyTask.class, MySubTask1.class, MySubTask2.class, MyTask1Ext.class, MyTask2Ext.class));

--- a/sql-test/src/main/java/com/easy/query/test/mysql8/M8IncludeLimitTest.java
+++ b/sql-test/src/main/java/com/easy/query/test/mysql8/M8IncludeLimitTest.java
@@ -1,0 +1,124 @@
+package com.easy.query.test.mysql8;
+
+import com.easy.query.api.proxy.client.DefaultEasyEntityQuery;
+import com.easy.query.api.proxy.client.EasyEntityQuery;
+import com.easy.query.core.api.client.EasyQueryClient;
+import com.easy.query.core.bootstrapper.EasyQueryBootstrapper;
+import com.easy.query.core.enums.IncludeLimitModeEnum;
+import com.easy.query.mysql.config.MySQLDatabaseConfiguration;
+import com.easy.query.test.mysql8.entity.M8IncludeLimitChild;
+import com.easy.query.test.mysql8.entity.M8IncludeLimitTopic;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * create time 2026/8/4
+ * include+limit 场景测试:
+ * 1. include+limit 且主实体含 @Column(autoSelect=false) 列时,PARTITION 模式生成 SQL 报 Unknown column 't1.deleted'
+ * 2. PARTITION 与 UNION_ALL 两种模式在分页+include limit 场景均返回完整关联(行为对照)
+ */
+public class M8IncludeLimitTest extends BaseTest {
+
+    private void clearData() {
+        easyEntityQuery.deletable(M8IncludeLimitTopic.class).disableLogicDelete().allowDeleteStatement(true).where(o -> o.id().isNotNull()).executeRows();
+        easyEntityQuery.deletable(M8IncludeLimitChild.class).disableLogicDelete().allowDeleteStatement(true).where(o -> o.id().isNotNull()).executeRows();
+    }
+
+    private void insertData() {
+        clearData();
+        M8IncludeLimitTopic t1 = new M8IncludeLimitTopic();
+        t1.setId("t1");
+        t1.setName("topic1");
+        M8IncludeLimitTopic t2 = new M8IncludeLimitTopic();
+        t2.setId("t2");
+        t2.setName("topic2");
+        M8IncludeLimitTopic t3 = new M8IncludeLimitTopic();
+        t3.setId("t3");
+        t3.setName("topic3");
+        easyEntityQuery.insertable(Arrays.asList(t1, t2, t3)).executeRows();
+
+        M8IncludeLimitChild c1 = child("c1", "t1", "child1", 1);
+        M8IncludeLimitChild c2 = child("c2", "t1", "child2", 2);
+        M8IncludeLimitChild c3 = child("c3", "t1", "child3", 3);
+        M8IncludeLimitChild c4 = child("c4", "t2", "child4", 1);
+        M8IncludeLimitChild c5 = child("c5", "t2", "child5", 2);
+        M8IncludeLimitChild c6 = child("c6", "t3", "child6", 1);
+        easyEntityQuery.insertable(Arrays.asList(c1, c2, c3, c4, c5, c6)).executeRows();
+    }
+
+    private M8IncludeLimitChild child(String id, String parentId, String name, Integer order) {
+        M8IncludeLimitChild child = new M8IncludeLimitChild();
+        child.setId(id);
+        child.setParentId(parentId);
+        child.setName(name);
+        child.setOrder(order);
+        return child;
+    }
+
+    /**
+     * include+limit 且主实体含 @Column(autoSelect=false) 列时:
+     * 修复前 PARTITION 模式报 Unknown column 't1.deleted'
+     * 修复后正常返回且关联条数受 limit 限制
+     */
+    @Test
+    public void testIncludeLimit() {
+        insertData();
+        List<M8IncludeLimitTopic> list = easyEntityQuery.queryable(M8IncludeLimitTopic.class)
+                .includes(m -> m.children(), s -> s.orderBy(x -> x.order().asc()).limit(2))
+                .toList();
+        Assert.assertEquals(3, list.size());
+        M8IncludeLimitTopic t1 = list.stream().filter(o -> "t1".equals(o.getId())).findFirst().orElse(null);
+        Assert.assertNotNull(t1);
+        Assert.assertEquals(2, t1.getChildren().size());
+        Assert.assertEquals("c1", t1.getChildren().get(0).getId());
+        Assert.assertEquals("c2", t1.getChildren().get(1).getId());
+        M8IncludeLimitTopic t3 = list.stream().filter(o -> "t3".equals(o.getId())).findFirst().orElse(null);
+        Assert.assertNotNull(t3);
+        Assert.assertEquals(1, t3.getChildren().size());
+        Assert.assertEquals("c6", t3.getChildren().get(0).getId());
+    }
+
+    /**
+     * PARTITION 模式:主表分页 offset>0 时 include limit 关联数据完整。
+     * 窗口参数来自 include 子查询自身(offset 恒 0,rows=include limit),每个主行独立分区取前 N 条,语义正确。
+     */
+    @Test
+    public void testIncludeLimitPagingPartition() {
+        insertData();
+        List<M8IncludeLimitTopic> page2 = easyEntityQuery.queryable(M8IncludeLimitTopic.class)
+                .orderBy(m -> m.id().asc())
+                .limit(2, 1)
+                .includes(m -> m.children(), s -> s.orderBy(x -> x.order().asc()).limit(2))
+                .toList();
+        Assert.assertEquals(1, page2.size());
+        Assert.assertEquals("t3", page2.get(0).getId());
+        Assert.assertEquals(1, page2.get(0).getChildren().size());
+        Assert.assertEquals("c6", page2.get(0).getChildren().get(0).getId());
+    }
+
+    /**
+     * UNION_ALL 模式:主表分页 offset>0 时 include limit 关联数据完整(正确行为)
+     */
+    @Test
+    public void testIncludeLimitPagingUnionAll() {
+        insertData();
+        EasyQueryClient unionAllClient = EasyQueryBootstrapper.defaultBuilderConfiguration()
+                .setDefaultDataSource(dataSource)
+                .optionConfigure(op -> op.setIncludeLimitMode(IncludeLimitModeEnum.UNION_ALL))
+                .useDatabaseConfigure(new MySQLDatabaseConfiguration())
+                .build();
+        EasyEntityQuery unionAllQuery = new DefaultEasyEntityQuery(unionAllClient);
+        List<M8IncludeLimitTopic> page2 = unionAllQuery.queryable(M8IncludeLimitTopic.class)
+                .orderBy(m -> m.id().asc())
+                .limit(2, 1)
+                .includes(m -> m.children(), s -> s.orderBy(x -> x.order().asc()).limit(2))
+                .toList();
+        Assert.assertEquals(1, page2.size());
+        Assert.assertEquals("t3", page2.get(0).getId());
+        Assert.assertEquals(1, page2.get(0).getChildren().size());
+        Assert.assertEquals("c6", page2.get(0).getChildren().get(0).getId());
+    }
+}

--- a/sql-test/src/main/java/com/easy/query/test/mysql8/entity/M8IncludeLimitChild.java
+++ b/sql-test/src/main/java/com/easy/query/test/mysql8/entity/M8IncludeLimitChild.java
@@ -1,0 +1,31 @@
+package com.easy.query.test.mysql8.entity;
+
+import com.easy.query.core.annotation.Column;
+import com.easy.query.core.annotation.EntityProxy;
+import com.easy.query.core.annotation.Table;
+import com.easy.query.core.proxy.ProxyEntityAvailable;
+import com.easy.query.test.mysql8.entity.proxy.M8IncludeLimitChildProxy;
+import lombok.Data;
+import lombok.experimental.FieldNameConstants;
+
+/**
+ * create time 2026/8/4
+ * include limit 场景专用实体
+ */
+@Data
+@EntityProxy
+@Table("m8_include_limit_child")
+@FieldNameConstants
+public class M8IncludeLimitChild implements ProxyEntityAvailable<M8IncludeLimitChild, M8IncludeLimitChildProxy> {
+    @Column(primaryKey = true)
+    private String id;
+
+    private String parentId;
+
+    private String name;
+
+    private Integer order;
+
+    @Column(autoSelect = false)
+    private Boolean deleted;
+}

--- a/sql-test/src/main/java/com/easy/query/test/mysql8/entity/M8IncludeLimitTopic.java
+++ b/sql-test/src/main/java/com/easy/query/test/mysql8/entity/M8IncludeLimitTopic.java
@@ -1,0 +1,37 @@
+package com.easy.query.test.mysql8.entity;
+
+import com.easy.query.core.annotation.Column;
+import com.easy.query.core.annotation.EntityProxy;
+import com.easy.query.core.annotation.Navigate;
+import com.easy.query.core.annotation.OrderByProperty;
+import com.easy.query.core.annotation.Table;
+import com.easy.query.core.enums.RelationTypeEnum;
+import com.easy.query.core.proxy.ProxyEntityAvailable;
+import com.easy.query.test.mysql8.entity.proxy.M8IncludeLimitTopicProxy;
+import lombok.Data;
+import lombok.experimental.FieldNameConstants;
+
+import java.util.List;
+
+/**
+ * create time 2026/8/4
+ * include limit 场景专用实体,包含 autoSelect=false 列用于复现 include+limit 场景的 Unknown column 缺陷
+ */
+@Data
+@EntityProxy
+@Table("m8_include_limit_topic")
+@FieldNameConstants
+public class M8IncludeLimitTopic implements ProxyEntityAvailable<M8IncludeLimitTopic, M8IncludeLimitTopicProxy> {
+    @Column(primaryKey = true)
+    private String id;
+
+    private String name;
+
+    @Navigate(value = RelationTypeEnum.OneToMany,
+            selfProperty = {M8IncludeLimitTopic.Fields.id},
+            targetProperty = {M8IncludeLimitChild.Fields.parentId},
+            orderByProps = {
+                    @OrderByProperty(property = "order")
+            })
+    private List<M8IncludeLimitChild> children;
+}


### PR DESCRIPTION
### 问题描述

`includes(...)` 带 `limit` 时(`include-limit-mode` 为 `PARTITION` 模式),若被关联实体(目标端)含 `@Column(autoSelect = false)` 的列(如逻辑删除列),生成的 SQL 会报错:

### 触发条件

三者缺一不可:
1. `includes(m -> m.xxx(), s -> s.limit(N))` 使用 include limit
2. `include-limit-mode = PARTITION`(默认值)
3. 被 include 的目标实体含 `@Column(autoSelect = false)` 列

### 根因

`EasyNavigateUtil.getNavigateLimitPartitionByQueryable` 中:
- 内层子查询用 `columnAll()` 投影，自动跳过 `autoSelect = false` 的列
- 外层 PartitionBy select 循环遍历目标实体全部列时**未跳过** `autoSelect = false` 列，仍生成 `t1.deleted` 引用
- 内外两层列集合不一致，导致 `Unknown column` SQL 错误

### 修复

外层 select 循环跳过 `!isAutoSelect()` 的列（3 行），与内层 `columnAll()` 行为对齐。

### 测试

新增 include+limit 场景专用测试（含缺陷复现与两种模式行为对照）：
- 实体：`M8IncludeLimitTopic` / `M8IncludeLimitChild`（child 含 `@Column(autoSelect = false)` 的 `deleted` 列）
- `M8IncludeLimitTest`：
  - `testIncludeLimit`：修复前稳定报 `Unknown column 't1.deleted'`，修复后正常返回、关联条数受 limit 限制、排序正确
  - `testIncludeLimitPagingPartition` / `testIncludeLimitPagingUnionAll`：PARTITION 与 UNION_ALL 分页 + include limit 关联完整性对照

回归：`M8IncludeOrderTest`、`M8CommentTest`、`IncludeConditionTest` 全部通过（7 tests）。

### 影响范围

低。仅在 `PARTITION + include limit + 目标实体含 autoSelect=false 列` 组合下触发；修复仅跳过不该出现的列，不改变查询语义。
